### PR TITLE
[feat] implement a separate `VmBuilder::build` method for `async` cases

### DIFF
--- a/.github/workflows/bindings-rust.yml
+++ b/.github/workflows/bindings-rust.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        rust: [1.69, 1.68]
+        rust: [1.70, 1.69, 1.68]
     container:
       image: wasmedge/wasmedge:ubuntu-build-clang
 
@@ -115,7 +115,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.69, 1.68]
+        rust: [1.70, 1.69, 1.68]
     container:
       image: fedora:latest
     steps:
@@ -200,7 +200,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-11, macos-12]
-        rust: [1.69, 1.68]
+        rust: [1.70, 1.69, 1.68]
 
     steps:
       - name: Checkout sources
@@ -263,7 +263,7 @@ jobs:
     runs-on: windows-2022
     strategy:
       matrix:
-        rust: [1.69, 1.68]
+        rust: [1.70, 1.69, 1.68]
     env:
       WASMEDGE_DIR: ${{ github.workspace }}\WasmEdge
       WASMEDGE_BUILD_DIR: ${{ github.workspace }}\WasmEdge\build

--- a/.github/workflows/bindings-rust.yml
+++ b/.github/workflows/bindings-rust.yml
@@ -26,6 +26,9 @@ on:
       - main
     paths:
       - ".github/workflows/bindings-rust.yml"
+      - "examples/**"
+      - "src/**"
+      - "crates/**"
 
 jobs:
   build_ubuntu:

--- a/.github/workflows/bindings-rust.yml
+++ b/.github/workflows/bindings-rust.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        rust: [1.70, 1.69, 1.68]
+        rust: [1.70.0, 1.69, 1.68]
     container:
       image: wasmedge/wasmedge:ubuntu-build-clang
 
@@ -115,7 +115,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.70, 1.69, 1.68]
+        rust: [1.70.0, 1.69, 1.68]
     container:
       image: fedora:latest
     steps:
@@ -200,7 +200,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-11, macos-12]
-        rust: [1.70, 1.69, 1.68]
+        rust: [1.70.0, 1.69, 1.68]
 
     steps:
       - name: Checkout sources
@@ -263,7 +263,7 @@ jobs:
     runs-on: windows-2022
     strategy:
       matrix:
-        rust: [1.70, 1.69, 1.68]
+        rust: [1.70.0, 1.69, 1.68]
     env:
       WASMEDGE_DIR: ${{ github.workspace }}\WasmEdge
       WASMEDGE_BUILD_DIR: ${{ github.workspace }}\WasmEdge\build

--- a/crates/wasmedge-sys/src/async_wasi.rs
+++ b/crates/wasmedge-sys/src/async_wasi.rs
@@ -163,9 +163,9 @@ pub fn args_sizes_get(
 pub fn environ_get(
     frame: CallingFrame,
     args: Vec<WasmValue>,
-    data: Option<&mut WasiCtx>,
+    ctx: Option<&mut WasiCtx>,
 ) -> std::result::Result<Vec<WasmValue>, HostFuncError> {
-    let data = data.unwrap();
+    let data = ctx.unwrap();
 
     let mut mem = frame.memory_mut(0).ok_or(HostFuncError::Runtime(0x88))?;
 

--- a/crates/wasmedge-sys/src/executor.rs
+++ b/crates/wasmedge-sys/src/executor.rs
@@ -370,8 +370,6 @@ mod tests {
         AsImport, CallingFrame, Config, FuncType, Function, Global, GlobalType, ImportModule,
         MemType, Memory, Statistics, Table, TableType,
     };
-    #[cfg(all(feature = "async", target_os = "linux"))]
-    use async_wasi::snapshots::WasiCtx;
     use std::{
         sync::{Arc, Mutex},
         thread,
@@ -593,13 +591,8 @@ mod tests {
         assert!(result.is_ok());
         let mut store = result.unwrap();
 
-        // create async wasi context
-        let mut async_wasi_ctx = WasiCtx::new();
-        async_wasi_ctx.push_arg("abc".into());
-        async_wasi_ctx.push_env("a=1".into());
-
         // create an AsyncWasiModule
-        let result = AsyncWasiModule::create(Some(&mut async_wasi_ctx));
+        let result = AsyncWasiModule::create(Some(vec!["abc"]), Some(vec![("a", "1")]), None);
         assert!(result.is_ok());
         let async_wasi_module = result.unwrap();
 
@@ -650,13 +643,8 @@ mod tests {
         assert!(result.is_ok());
         let mut store = result.unwrap();
 
-        // create async wasi context
-        let mut async_wasi_ctx = WasiCtx::new();
-        async_wasi_ctx.push_arg("abc".into());
-        async_wasi_ctx.push_env("a=1".into());
-
         // create an AsyncWasiModule
-        let result = AsyncWasiModule::create(Some(&mut async_wasi_ctx));
+        let result = AsyncWasiModule::create(Some(vec!["abc"]), Some(vec![("a", "1")]), None);
         assert!(result.is_ok());
         let async_wasi_module = result.unwrap();
 

--- a/crates/wasmedge-sys/src/lib.rs
+++ b/crates/wasmedge-sys/src/lib.rs
@@ -114,6 +114,9 @@ pub use types::WasmValue;
 pub use validator::Validator;
 use wasmedge_types::{error, WasmEdgeResult};
 
+#[cfg(all(feature = "async", target_os = "linux"))]
+pub type WasiCtx = ::async_wasi::snapshots::WasiCtx;
+
 /// The object that is used to perform a [host function](crate::Function) is required to implement this trait.
 pub trait Engine {
     /// Runs a host function instance and returns the results.

--- a/examples/async_hello_world.rs
+++ b/examples/async_hello_world.rs
@@ -50,9 +50,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .with_func_async::<(), (), NeverType>("say_hello", say_hello, None)?
             .build("extern")?;
 
-        let vm = VmBuilder::new()
-            .build(None)?
-            .register_import_module(import)?;
+        let vm = VmBuilder::new().build()?.register_import_module(import)?;
 
         tokio::spawn(async move {
             let async_state = AsyncState::new();

--- a/examples/async_hello_world.rs
+++ b/examples/async_hello_world.rs
@@ -4,13 +4,13 @@
 //! cargo run -p wasmedge-sdk --features async --example async_hello_world -- --nocapture
 //! ```
 //!
-#[cfg(feature = "async")]
+#[cfg(all(feature = "async", target_os = "linux"))]
 use wasmedge_sdk::{
     async_host_function, error::HostFuncError, params, r#async::AsyncState, Caller,
     ImportObjectBuilder, NeverType, VmBuilder, WasmValue,
 };
 
-#[cfg(feature = "async")]
+#[cfg(all(feature = "async", target_os = "linux"))]
 #[async_host_function]
 async fn say_hello<T>(
     caller: Caller,
@@ -43,14 +43,16 @@ async fn say_hello<T>(
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    #[cfg(feature = "async")]
+    #[cfg(all(feature = "async", target_os = "linux"))]
     {
         // create an import module
         let import = ImportObjectBuilder::new()
             .with_func_async::<(), (), NeverType>("say_hello", say_hello, None)?
             .build("extern")?;
 
-        let vm = VmBuilder::new().build()?.register_import_module(import)?;
+        let vm = VmBuilder::new()
+            .build(None)?
+            .register_import_module(import)?;
 
         tokio::spawn(async move {
             let async_state = AsyncState::new();

--- a/examples/async_run_func.rs
+++ b/examples/async_run_func.rs
@@ -5,7 +5,7 @@
 //! cd <wasmedge-root-dir>/bindings/rust/
 //! cargo run -p wasmedge-sdk --features async --example async_run_func
 //! ```
-#[cfg(feature = "async")]
+#[cfg(all(feature = "async", target_os = "linux"))]
 use wasmedge_sdk::{
     config::{CommonConfigOptions, ConfigBuilder},
     params,
@@ -15,7 +15,7 @@ use wasmedge_sdk::{
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    #[cfg(feature = "async")]
+    #[cfg(all(feature = "async", target_os = "linux"))]
     {
         let wasm_file = std::env::current_dir()?.join("examples/data/fibonacci.wat");
 
@@ -25,7 +25,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // create Vm instance
         let vm = VmBuilder::new()
             .with_config(config)
-            .build()?
+            .build(None)?
             .register_module_from_file("extern", wasm_file)?;
 
         // async run function

--- a/examples/async_run_func.rs
+++ b/examples/async_run_func.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // create Vm instance
         let vm = VmBuilder::new()
             .with_config(config)
-            .build(None)?
+            .build()?
             .register_module_from_file("extern", wasm_file)?;
 
         // async run function

--- a/examples/create_host_func_in_host_func.rs
+++ b/examples/create_host_func_in_host_func.rs
@@ -1,8 +1,10 @@
+#[cfg(not(feature = "async"))]
 use wasmedge_sdk::{
     error::HostFuncError, host_function, params, Caller, Executor, Func, ImportObjectBuilder,
     NeverType, ValType, VmBuilder, WasmVal, WasmValue,
 };
 
+#[cfg(not(feature = "async"))]
 #[host_function]
 fn func<T>(
     _caller: Caller,
@@ -65,15 +67,18 @@ fn func<T>(
 
 #[cfg_attr(test, test)]
 fn main() -> anyhow::Result<()> {
-    // create an import module
-    let import = ImportObjectBuilder::new()
-        .with_func::<(), (), NeverType>("outer-func", func, None)?
-        .build("extern")?;
+    #[cfg(not(feature = "async"))]
+    {
+        // create an import module
+        let import = ImportObjectBuilder::new()
+            .with_func::<(), (), NeverType>("outer-func", func, None)?
+            .build("extern")?;
 
-    let _ = VmBuilder::new()
-        .build()?
-        .register_import_module(import)?
-        .run_func(Some("extern"), "outer-func", params!())?;
+        let _ = VmBuilder::new()
+            .build()?
+            .register_import_module(import)?
+            .run_func(Some("extern"), "outer-func", params!())?;
+    }
 
     Ok(())
 }

--- a/examples/run_func_in_aot_mode.rs
+++ b/examples/run_func_in_aot_mode.rs
@@ -5,9 +5,9 @@
 //! cargo run -p wasmedge-sdk --example run_func_in_aot_mode -- --nocapture
 //! ```
 
-#[cfg(all(feature = "aot", target_family = "unix"))]
+#[cfg(all(feature = "aot", target_family = "unix", not(feature = "async")))]
 use std::os::unix::fs::PermissionsExt;
-#[cfg(all(feature = "aot", target_family = "unix"))]
+#[cfg(all(feature = "aot", target_family = "unix", not(feature = "async")))]
 use wasmedge_sdk::{
     config::{
         CommonConfigOptions, CompilerConfigOptions, ConfigBuilder, HostRegistrationConfigOptions,
@@ -17,7 +17,7 @@ use wasmedge_sdk::{
 
 #[cfg_attr(test, test)]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    #[cfg(all(feature = "aot", target_family = "unix"))]
+    #[cfg(all(feature = "aot", target_family = "unix", not(feature = "async")))]
     {
         // create a Config context
         let config = ConfigBuilder::new(CommonConfigOptions::new().bulk_memory_operations(true))

--- a/examples/vm.rs
+++ b/examples/vm.rs
@@ -3,17 +3,21 @@
 // If the version of rust used is less than v1.63, please uncomment the follow attribute.
 // #![feature(explicit_generic_args_with_impl_trait)]
 
+#[cfg(not(feature = "async"))]
 use wasmedge_sdk::{params, VmBuilder, WasmVal};
+#[cfg(not(feature = "async"))]
 use wasmedge_types::wat2wasm;
 
 #[cfg_attr(test, test)]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // create a Vm context
-    let vm = VmBuilder::new().build()?;
+    #[cfg(not(feature = "async"))]
+    {
+        // create a Vm context
+        let vm = VmBuilder::new().build()?;
 
-    // register a wasm module from the given in-memory wasm bytes
-    let wasm_bytes = wat2wasm(
-        br#"(module
+        // register a wasm module from the given in-memory wasm bytes
+        let wasm_bytes = wat2wasm(
+            br#"(module
         (export "fib" (func $fib))
         (func $fib (param $n i32) (result i32)
          (if
@@ -44,13 +48,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
        )
     "#,
-    )?;
-    let vm = vm.register_module_from_bytes("extern", wasm_bytes)?;
+        )?;
+        let vm = vm.register_module_from_bytes("extern", wasm_bytes)?;
 
-    // run `fib` function in the named module instance
-    let returns = vm.run_func(Some("extern"), "fib", params!(10))?;
-    assert_eq!(returns.len(), 1);
-    assert_eq!(returns[0].to_i32(), 89);
+        // run `fib` function in the named module instance
+        let returns = vm.run_func(Some("extern"), "fib", params!(10))?;
+        assert_eq!(returns.len(), 1);
+        assert_eq!(returns[0].to_i32(), 89);
+    }
 
     Ok(())
 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -91,6 +91,7 @@ impl Compiler {
     }
 }
 
+#[cfg(not(feature = "async"))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -131,9 +131,9 @@ mod tests {
         config::{CommonConfigOptions, ConfigBuilder},
         params, wat2wasm, Module, Statistics, Store, WasmVal,
     };
-    #[cfg(feature = "async")]
+    #[cfg(all(feature = "async", target_os = "linux"))]
     use crate::{error::HostFuncError, CallingFrame};
-    #[cfg(feature = "async")]
+    #[cfg(all(feature = "async", target_os = "linux"))]
     use wasmedge_types::NeverType;
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,6 +166,9 @@ pub mod r#async {
     pub type AsyncHostFn<T> = wasmedge_sys::AsyncHostFn<T>;
 }
 
+#[cfg(all(feature = "async", target_os = "linux"))]
+pub type WasiCtx = wasmedge_sys::WasiCtx;
+
 /// The object that is used to perform a [host function](crate::Func) is required to implement this trait.
 pub trait Engine {
     /// Runs a host function instance and returns the results.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@
 //! The example below is using `wasmedge-sdk` to run a WebAssembly module written with its WAT format (textual format). If you would like more examples, please refer to [Examples of WasmEdge RustSDK](https://github.com/second-state/wasmedge-rustsdk-examples).
 //!
 //!  ```rust
+//!  #[cfg(not(feature = "async"))]
 //!  use wasmedge_sdk::{
 //!      error::HostFuncError, host_function, params, wat2wasm, Caller, ImportObjectBuilder, Module,
 //!      VmBuilder, WasmValue, NeverType
@@ -42,6 +43,7 @@
 //!  
 //!  // We define a function to act as our "env" "say_hello" function imported in the
 //!  // Wasm program above.
+//!  #[cfg(not(feature = "async"))]
 //!  #[host_function]
 //!  pub fn say_hello<T>(_caller: Caller, _args: Vec<WasmValue>, _data: Option<&mut T>) -> Result<Vec<WasmValue>, HostFuncError> {
 //!      println!("Hello, world!");
@@ -51,38 +53,41 @@
 //!  
 //!  #[cfg_attr(test, test)]
 //!  fn main() -> anyhow::Result<()> {
-//!      // create an import module
-//!      let import = ImportObjectBuilder::new()
-//!          .with_func::<(), (), NeverType>("say_hello", say_hello, None)?
-//!          .build("env")?;
-//!  
-//!      let wasm_bytes = wat2wasm(
-//!          br#"
-//!      (module
-//!        ;; First we define a type with no parameters and no results.
-//!        (type $no_args_no_rets_t (func (param) (result)))
+//!      #[cfg(not(feature = "async"))]
+//!      {
+//!          // create an import module
+//!          let import = ImportObjectBuilder::new()
+//!              .with_func::<(), (), NeverType>("say_hello", say_hello, None)?
+//!              .build("env")?;
 //!      
-//!        ;; Then we declare that we want to import a function named "env" "say_hello" with
-//!        ;; that type signature.
-//!        (import "env" "say_hello" (func $say_hello (type $no_args_no_rets_t)))
+//!          let wasm_bytes = wat2wasm(
+//!              br#"
+//!          (module
+//!            ;; First we define a type with no parameters and no results.
+//!            (type $no_args_no_rets_t (func (param) (result)))
+//!          
+//!            ;; Then we declare that we want to import a function named "env" "say_hello" with
+//!            ;; that type signature.
+//!            (import "env" "say_hello" (func $say_hello (type $no_args_no_rets_t)))
+//!          
+//!            ;; Finally we create an entrypoint that calls our imported function.
+//!            (func $run (type $no_args_no_rets_t)
+//!              (call $say_hello))
+//!            ;; And mark it as an exported function named "run".
+//!            (export "run" (func $run)))
+//!          "#,
+//!          )?;
 //!      
-//!        ;; Finally we create an entrypoint that calls our imported function.
-//!        (func $run (type $no_args_no_rets_t)
-//!          (call $say_hello))
-//!        ;; And mark it as an exported function named "run".
-//!        (export "run" (func $run)))
-//!      "#,
-//!      )?;
-//!  
-//!      // loads a wasm module from the given in-memory bytes
-//!      let module = Module::from_bytes(None, wasm_bytes)?;
-//!  
-//!      // create an executor
-//!      VmBuilder::new()
-//!          .build()?
-//!          .register_import_module(import)?
-//!          .register_module(Some("extern"), module)?
-//!          .run_func(Some("extern"), "run", params!())?;
+//!          // loads a wasm module from the given in-memory bytes
+//!          let module = Module::from_bytes(None, wasm_bytes)?;
+//!      
+//!          // create an executor
+//!          VmBuilder::new()
+//!              .build()?
+//!              .register_import_module(import)?
+//!              .register_module(Some("extern"), module)?
+//!              .run_func(Some("extern"), "run", params!())?;
+//!      }
 //!  
 //!      Ok(())
 //!  }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -244,55 +244,57 @@ impl VmBuilder {
 /// ```rust
 /// // If the version of rust used is less than v1.63, please uncomment the follow attribute.
 /// // #![feature(explicit_generic_args_with_impl_trait)]
-///
-/// use wasmedge_sdk::{params, VmBuilder, WasmVal};
-/// use wasmedge_types::{wat2wasm, ValType};
+/// #[cfg(not(feature = "async"))]
+/// use wasmedge_sdk::{params, VmBuilder, WasmVal, wat2wasm, ValType};
 ///
 /// #[cfg_attr(test, test)]
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     // create a Vm context
-///     let vm = VmBuilder::new().build()?;
+///     #[cfg(not(feature = "async"))]
+///     {
+///         // create a Vm context
+///         let vm = VmBuilder::new().build()?;
 ///
-///     // register a wasm module from the given in-memory wasm bytes
-///     let wasm_bytes = wat2wasm(
-///         br#"(module
-///         (export "fib" (func $fib))
-///         (func $fib (param $n i32) (result i32)
-///          (if
-///           (i32.lt_s
-///            (get_local $n)
-///            (i32.const 2)
-///           )
-///           (return
-///            (i32.const 1)
-///           )
-///          )
-///          (return
-///           (i32.add
-///            (call $fib
-///             (i32.sub
-///              (get_local $n)
-///              (i32.const 2)
+///         // register a wasm module from the given in-memory wasm bytes
+///         let wasm_bytes = wat2wasm(
+///             br#"(module
+///             (export "fib" (func $fib))
+///             (func $fib (param $n i32) (result i32)
+///              (if
+///               (i32.lt_s
+///                (get_local $n)
+///                (i32.const 2)
+///               )
+///               (return
+///                (i32.const 1)
+///               )
+///              )
+///              (return
+///               (i32.add
+///                (call $fib
+///                 (i32.sub
+///                  (get_local $n)
+///                  (i32.const 2)
+///                 )
+///                )
+///                (call $fib
+///                 (i32.sub
+///                  (get_local $n)
+///                  (i32.const 1)
+///                 )
+///                )
+///               )
+///              )
 ///             )
 ///            )
-///            (call $fib
-///             (i32.sub
-///              (get_local $n)
-///              (i32.const 1)
-///             )
-///            )
-///           )
-///          )
-///         )
-///        )
-///     "#,
-///     )?;
-///     let mut vm = vm.register_module_from_bytes("extern", wasm_bytes)?;
+///         "#,
+///         )?;
+///         let mut vm = vm.register_module_from_bytes("extern", wasm_bytes)?;
 ///
-///     // run `fib` function in the named module instance
-///     let returns = vm.run_func(Some("extern"), "fib", params!(10))?;
-///     assert_eq!(returns.len(), 1);
-///     assert_eq!(returns[0].to_i32(), 89);
+///         // run `fib` function in the named module instance
+///         let returns = vm.run_func(Some("extern"), "fib", params!(10))?;
+///         assert_eq!(returns.len(), 1);
+///         assert_eq!(returns[0].to_i32(), 89);
+///     }
 ///
 ///     Ok(())
 /// }

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -177,6 +177,48 @@ pub struct WasiInstance {
     pub(crate) inner: sys::AsyncWasiModule,
 }
 #[cfg(all(feature = "async", target_os = "linux"))]
+impl WasiInstance {
+    /// Initializes the WASI host module with the given parameters.
+    ///
+    /// # Arguments
+    ///
+    /// * `args` - The commandline arguments. Note that the first argument is the program name.
+    ///
+    /// * `envs` - The environment variables.
+    ///
+    /// * `preopens` - The directories to pre-open.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let wasi_module = vm.wasi_module_mut().ok_or("failed to get wasi module")?;
+    /// wasi_module.initialize(
+    ///     None,
+    ///     Some(vec![("ENV", "VAL")]),
+    ///     Some(vec![(
+    ///         std::path::PathBuf::from("."),
+    ///         std::path::PathBuf::from("."),
+    ///     )]),
+    /// )?;
+    /// ```
+    ///
+    pub fn initialize(
+        &mut self,
+        args: Option<Vec<&str>>,
+        envs: Option<Vec<(&str, &str)>>,
+        preopens: Option<Vec<(std::path::PathBuf, std::path::PathBuf)>>,
+    ) -> WasmEdgeResult<()> {
+        self.inner.init_wasi(args, envs, preopens)
+    }
+
+    /// Returns the WASI exit code.
+    ///
+    /// The WASI exit code can be accessed after running the "_start" function of a `wasm32-wasi` program.
+    pub fn exit_code(&self) -> u32 {
+        self.inner.exit_code()
+    }
+}
+#[cfg(all(feature = "async", target_os = "linux"))]
 impl AsInstance for WasiInstance {
     fn name(&self) -> &str {
         self.inner.name()


### PR DESCRIPTION
In this PR a separate `build` method is implemented in `VmBuilder` for creating a `Vm` with the support for `AsyncWasiModule`.