### PR TITLE
[feat] Support new WasmEdge C-APIs

### DIFF
--- a/crates/wasmedge-sys/src/utils.rs
+++ b/crates/wasmedge-sys/src/utils.rs
@@ -380,3 +380,26 @@ where
 
     unsafe { ffi::WasmEdge_Driver_Tool(c_args.len() as std::os::raw::c_int, c_args.as_mut_ptr()) }
 }
+
+/// Triggers the WasmEdge unified tool
+pub fn driver_unified_tool<I, V>(args: I) -> i32
+where
+    I: IntoIterator<Item = V>,
+    V: AsRef<str>,
+{
+    // create a vector of zero terminated strings
+    let args = args
+        .into_iter()
+        .map(|arg| CString::new(arg.as_ref()).unwrap())
+        .collect::<Vec<CString>>();
+
+    // convert the strings to raw pointers
+    let mut c_args = args
+        .iter()
+        .map(|arg| arg.as_ptr())
+        .collect::<Vec<*const std::os::raw::c_char>>();
+
+    unsafe {
+        ffi::WasmEdge_Driver_UniTool(c_args.len() as std::os::raw::c_int, c_args.as_mut_ptr())
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -21,4 +21,13 @@ impl Driver {
     {
         utils::driver_runtime_tool(args)
     }
+
+    /// Triggers the WasmEdge unified tool
+    pub fn unified_tool<I, V>(args: I) -> i32
+    where
+        I: IntoIterator<Item = V>,
+        V: AsRef<str>,
+    {
+        utils::driver_unified_tool(args)
+    }
 }


### PR DESCRIPTION
In this PR, the following new WasmEdge C-API is supported in Rust SDK:

- `WasmEdge_Driver_UniTool`