### PR TITLE
[CI] Support macOS and Fedora in the `standalone` workflow

### DIFF
--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -31,75 +31,75 @@ on:
       - "crates/**"
 
 jobs:
-  # build_ubuntu:
-  #   name: Ubuntu
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-22.04, ubuntu-20.04]
-  #       rust: [1.70.0, 1.69, 1.68]
+  build_ubuntu:
+    name: Ubuntu
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-20.04]
+        rust: [1.70.0, 1.69, 1.68]
 
-  #   steps:
-  #     - name: Checkout WasmEdge Rust SDK
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
+    steps:
+      - name: Checkout WasmEdge Rust SDK
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-  #     - name: Set up build environment
-  #       run: |
-  #         sudo apt-get update
-  #         sudo apt-get install -y software-properties-common libboost-all-dev ninja-build
-  #         sudo apt-get install -y llvm-14-dev liblld-14-dev clang-14
-  #         sudo apt-get install -y gcc g++
-  #         sudo apt-get install -y libssl-dev pkg-config gh
+      - name: Set up build environment
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y software-properties-common libboost-all-dev ninja-build
+          sudo apt-get install -y llvm-14-dev liblld-14-dev clang-14
+          sudo apt-get install -y gcc g++
+          sudo apt-get install -y libssl-dev pkg-config gh
 
-  #     - name: Install Rust stable
-  #       uses: dtolnay/rust-toolchain@stable
-  #       with:
-  #         toolchain: ${{ matrix.rust }}
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.rust }}
 
-  #     - name: Run in the standalone mode
-  #       run: |
-  #         export LLVM_DIR="/usr/local/opt/llvm/lib/cmake"
-  #         export CC=clang
-  #         export CXX=clang++
-  #         export LD_LIBRARY_PATH=$HOME/.wasmedge/lib
-  #         cargo test -p wasmedge-sdk --all --examples --features standalone
+      - name: Run in the standalone mode
+        run: |
+          export LLVM_DIR="/usr/local/opt/llvm/lib/cmake"
+          export CC=clang
+          export CXX=clang++
+          export LD_LIBRARY_PATH=$HOME/.wasmedge/lib
+          cargo test -p wasmedge-sdk --all --examples --features standalone
 
-  # build_fedora:
-  #   name: Fedora latest
-  #   runs-on: Fedora-latest
-  #   strategy:
-  #     matrix:
-  #       rust: [1.70.0, 1.69, 1.68]
-  #   container:
-  #     image: fedora:latest
+  build_fedora:
+    name: Fedora latest
+    runs-on: Fedora-latest
+    strategy:
+      matrix:
+        rust: [1.70.0, 1.69, 1.68]
+    container:
+      image: fedora:latest
 
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-  #     - name: Set up build environment
-  #       run: |
-  #         sudo apt-get update
-  #         sudo apt-get install -y software-properties-common libboost-all-dev ninja-build
-  #         sudo apt-get install -y llvm-12-dev liblld-12-dev clang-12
-  #         sudo apt-get install -y gcc g++
-  #         sudo apt-get install -y libssl-dev pkg-config gh
+      - name: Set up build environment
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y software-properties-common libboost-all-dev ninja-build
+          sudo apt-get install -y llvm-12-dev liblld-12-dev clang-12
+          sudo apt-get install -y gcc g++
+          sudo apt-get install -y libssl-dev pkg-config gh
 
-  #     - name: Install Rust stable
-  #       uses: dtolnay/rust-toolchain@stable
-  #       with:
-  #         toolchain: ${{ matrix.rust }}
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.rust }}
 
-  #     - name: Run in the standalone mode
-  #       run: |
-  #         export LLVM_DIR="/usr/local/opt/llvm/lib/cmake"
-  #         export CC=clang
-  #         export CXX=clang++
-  #         export LD_LIBRARY_PATH=$HOME/.wasmedge/lib
-  #         cargo test -p wasmedge-sdk --all --examples --features standalone
+      - name: Run in the standalone mode
+        run: |
+          export LLVM_DIR="/usr/local/opt/llvm/lib/cmake"
+          export CC=clang
+          export CXX=clang++
+          export LD_LIBRARY_PATH=$HOME/.wasmedge/lib
+          cargo test -p wasmedge-sdk --all --examples --features standalone
 
   build_macos:
     name: MacOS

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -18,7 +18,7 @@ on:
       - "ci/*"
       - "release/*"
     paths:
-      - ".github/workflows/bindings-rust.yml"
+      - ".github/workflows/standalone.yml"
       - "src/**"
       - "crates/**"
 
@@ -26,7 +26,7 @@ on:
     branches:
       - main
     paths:
-      - ".github/workflows/bindings-rust.yml"
+      - ".github/workflows/standalone.yml"
       - "src/**"
       - "crates/**"
 

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -4,31 +4,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-# on: workflow_dispatch
-
-on:
-  push:
-    branches:
-      - main
-      - "feat/*"
-      - "refactor/*"
-      - "test/*"
-      - "fix/*"
-      - "doc/*"
-      - "ci/*"
-      - "release/*"
-    paths:
-      - ".github/workflows/standalone.yml"
-      - "src/**"
-      - "crates/**"
-
-  pull_request:
-    branches:
-      - main
-    paths:
-      - ".github/workflows/standalone.yml"
-      - "src/**"
-      - "crates/**"
+on: workflow_dispatch
 
 jobs:
   build_ubuntu_2204:

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -4,108 +4,130 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-on: workflow_dispatch
+# on: workflow_dispatch
+
+on:
+  push:
+    branches:
+      - main
+      - "feat/*"
+      - "refactor/*"
+      - "test/*"
+      - "fix/*"
+      - "doc/*"
+      - "ci/*"
+      - "release/*"
+    paths:
+      - ".github/workflows/bindings-rust.yml"
+      - "src/**"
+      - "crates/**"
+
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/bindings-rust.yml"
+      - "src/**"
+      - "crates/**"
 
 jobs:
-  build_ubuntu:
-    name: Ubuntu
+  # build_ubuntu:
+  #   name: Ubuntu
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-22.04, ubuntu-20.04]
+  #       rust: [1.70.0, 1.69, 1.68]
+
+  #   steps:
+  #     - name: Checkout WasmEdge Rust SDK
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+
+  #     - name: Set up build environment
+  #       run: |
+  #         sudo apt-get update
+  #         sudo apt-get install -y software-properties-common libboost-all-dev ninja-build
+  #         sudo apt-get install -y llvm-14-dev liblld-14-dev clang-14
+  #         sudo apt-get install -y gcc g++
+  #         sudo apt-get install -y libssl-dev pkg-config gh
+
+  #     - name: Install Rust stable
+  #       uses: dtolnay/rust-toolchain@stable
+  #       with:
+  #         toolchain: ${{ matrix.rust }}
+
+  #     - name: Run in the standalone mode
+  #       run: |
+  #         export LLVM_DIR="/usr/local/opt/llvm/lib/cmake"
+  #         export CC=clang
+  #         export CXX=clang++
+  #         export LD_LIBRARY_PATH=$HOME/.wasmedge/lib
+  #         cargo test -p wasmedge-sdk --all --examples --features standalone
+
+  # build_fedora:
+  #   name: Fedora latest
+  #   runs-on: Fedora-latest
+  #   strategy:
+  #     matrix:
+  #       rust: [1.70.0, 1.69, 1.68]
+  #   container:
+  #     image: fedora:latest
+
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+
+  #     - name: Set up build environment
+  #       run: |
+  #         sudo apt-get update
+  #         sudo apt-get install -y software-properties-common libboost-all-dev ninja-build
+  #         sudo apt-get install -y llvm-12-dev liblld-12-dev clang-12
+  #         sudo apt-get install -y gcc g++
+  #         sudo apt-get install -y libssl-dev pkg-config gh
+
+  #     - name: Install Rust stable
+  #       uses: dtolnay/rust-toolchain@stable
+  #       with:
+  #         toolchain: ${{ matrix.rust }}
+
+  #     - name: Run in the standalone mode
+  #       run: |
+  #         export LLVM_DIR="/usr/local/opt/llvm/lib/cmake"
+  #         export CC=clang
+  #         export CXX=clang++
+  #         export LD_LIBRARY_PATH=$HOME/.wasmedge/lib
+  #         cargo test -p wasmedge-sdk --all --examples --features standalone
+
+  build_macos:
+    name: MacOS
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [macos-11, macos-12]
         rust: [1.70.0, 1.69, 1.68]
 
     steps:
-      - name: Checkout WasmEdge Rust SDK
+      - name: Checkout sources
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - name: Set up build environment
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y software-properties-common libboost-all-dev ninja-build
-          sudo apt-get install -y llvm-14-dev liblld-14-dev clang-14
-          sudo apt-get install -y gcc g++
-          sudo apt-get install -y libssl-dev pkg-config gh
-
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
 
-      - name: Run in the standalone mode
+      - name: Install build tools
+        run: brew install llvm ninja boost cmake
+
+      - name: Install libwasmedge
+        working-directory: bindings/rust/
         run: |
           export LLVM_DIR="/usr/local/opt/llvm/lib/cmake"
           export CC=clang
           export CXX=clang++
-          export LD_LIBRARY_PATH=$HOME/.wasmedge/lib
+          export DYLD_LIBRARY_PATH=$HOME/.wasmedge/lib
           cargo test -p wasmedge-sdk --all --examples --features standalone
-
-  build_fedora:
-    name: Fedora latest
-    runs-on: Fedora-latest
-    strategy:
-      matrix:
-        rust: [1.70.0, 1.69, 1.68]
-    container:
-      image: fedora:latest
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Set up build environment
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y software-properties-common libboost-all-dev ninja-build
-          sudo apt-get install -y llvm-12-dev liblld-12-dev clang-12
-          sudo apt-get install -y gcc g++
-          sudo apt-get install -y libssl-dev pkg-config gh
-
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ matrix.rust }}
-      
-      
-      - name: Run in the standalone mode
-        run: |
-          export LLVM_DIR="/usr/local/opt/llvm/lib/cmake"
-          export CC=clang
-          export CXX=clang++
-          export LD_LIBRARY_PATH=$HOME/.wasmedge/lib
-          cargo test -p wasmedge-sdk --all --examples --features standalone
-
-#   build_macos:
-#     name: MacOS
-#     runs-on: ${{ matrix.os }}
-#     strategy:
-#       matrix:
-#         os: [macos-11, macos-12]
-
-#     steps:
-#       - name: Checkout sources
-#         uses: actions/checkout@v3
-#         with:
-#           fetch-depth: 0
-
-#       - name: Install Rust v1.68
-#         uses: dtolnay/rust-toolchain@stable
-#         with:
-#           toolchain: 1.68
-
-#       - name: Install build tools
-#         run: brew install llvm ninja boost cmake
-
-#       - name: Install libwasmedge
-#         working-directory: bindings/rust/
-#         run: |
-#           export LLVM_DIR="/usr/local/opt/llvm/lib/cmake"
-#           export CC=clang
-#           export CXX=clang++
-#           export DYLD_LIBRARY_PATH="/Users/runner/.wasmedge/lib"
-#           export WASMEDGE_DIR="$(pwd)/../../"
-#           cargo +nightly -Z sparse-registry update
-#           cargo test -p wasmedge-sdk --all --examples --features standalone

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -124,7 +124,6 @@ jobs:
         run: brew install llvm ninja boost cmake
 
       - name: Install libwasmedge
-        working-directory: bindings/rust/
         run: |
           export LLVM_DIR="/usr/local/opt/llvm/lib/cmake"
           export CC=clang

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -31,12 +31,11 @@ on:
       - "crates/**"
 
 jobs:
-  build_ubuntu:
+  build_ubuntu_2204:
     name: Ubuntu
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04]
         rust: [1.70.0, 1.69, 1.68]
 
     steps:
@@ -50,6 +49,40 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y software-properties-common libboost-all-dev ninja-build
           sudo apt-get install -y llvm-14-dev liblld-14-dev clang-14
+          sudo apt-get install -y gcc g++
+          sudo apt-get install -y libssl-dev pkg-config gh
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.rust }}
+
+      - name: Run in the standalone mode
+        run: |
+          export LLVM_DIR="/usr/local/opt/llvm/lib/cmake"
+          export CC=clang
+          export CXX=clang++
+          export LD_LIBRARY_PATH=$HOME/.wasmedge/lib
+          cargo test -p wasmedge-sdk --all --examples --features standalone
+
+  build_ubuntu_2004:
+    name: Ubuntu
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        rust: [1.70.0, 1.69, 1.68]
+
+    steps:
+      - name: Checkout WasmEdge Rust SDK
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up build environment
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y software-properties-common libboost-all-dev ninja-build
+          sudo apt-get install -y llvm-12-dev liblld-12-dev clang-12
           sudo apt-get install -y gcc g++
           sudo apt-get install -y libssl-dev pkg-config gh
 

--- a/crates/wasmedge-sys/src/utils.rs
+++ b/crates/wasmedge-sys/src/utils.rs
@@ -381,25 +381,25 @@ where
     unsafe { ffi::WasmEdge_Driver_Tool(c_args.len() as std::os::raw::c_int, c_args.as_mut_ptr()) }
 }
 
-// /// Triggers the WasmEdge unified tool
-// pub fn driver_unified_tool<I, V>(args: I) -> i32
-// where
-//     I: IntoIterator<Item = V>,
-//     V: AsRef<str>,
-// {
-//     // create a vector of zero terminated strings
-//     let args = args
-//         .into_iter()
-//         .map(|arg| CString::new(arg.as_ref()).unwrap())
-//         .collect::<Vec<CString>>();
+/// Triggers the WasmEdge unified tool
+pub fn driver_unified_tool<I, V>(args: I) -> i32
+where
+    I: IntoIterator<Item = V>,
+    V: AsRef<str>,
+{
+    // create a vector of zero terminated strings
+    let args = args
+        .into_iter()
+        .map(|arg| CString::new(arg.as_ref()).unwrap())
+        .collect::<Vec<CString>>();
 
-//     // convert the strings to raw pointers
-//     let mut c_args = args
-//         .iter()
-//         .map(|arg| arg.as_ptr())
-//         .collect::<Vec<*const std::os::raw::c_char>>();
+    // convert the strings to raw pointers
+    let mut c_args = args
+        .iter()
+        .map(|arg| arg.as_ptr())
+        .collect::<Vec<*const std::os::raw::c_char>>();
 
-//     unsafe {
-//         ffi::WasmEdge_Driver_UniTool(c_args.len() as std::os::raw::c_int, c_args.as_mut_ptr())
-//     }
-// }
+    unsafe {
+        ffi::WasmEdge_Driver_UniTool(c_args.len() as std::os::raw::c_int, c_args.as_mut_ptr())
+    }
+}

--- a/crates/wasmedge-sys/src/utils.rs
+++ b/crates/wasmedge-sys/src/utils.rs
@@ -381,25 +381,25 @@ where
     unsafe { ffi::WasmEdge_Driver_Tool(c_args.len() as std::os::raw::c_int, c_args.as_mut_ptr()) }
 }
 
-/// Triggers the WasmEdge unified tool
-pub fn driver_unified_tool<I, V>(args: I) -> i32
-where
-    I: IntoIterator<Item = V>,
-    V: AsRef<str>,
-{
-    // create a vector of zero terminated strings
-    let args = args
-        .into_iter()
-        .map(|arg| CString::new(arg.as_ref()).unwrap())
-        .collect::<Vec<CString>>();
+// /// Triggers the WasmEdge unified tool
+// pub fn driver_unified_tool<I, V>(args: I) -> i32
+// where
+//     I: IntoIterator<Item = V>,
+//     V: AsRef<str>,
+// {
+//     // create a vector of zero terminated strings
+//     let args = args
+//         .into_iter()
+//         .map(|arg| CString::new(arg.as_ref()).unwrap())
+//         .collect::<Vec<CString>>();
 
-    // convert the strings to raw pointers
-    let mut c_args = args
-        .iter()
-        .map(|arg| arg.as_ptr())
-        .collect::<Vec<*const std::os::raw::c_char>>();
+//     // convert the strings to raw pointers
+//     let mut c_args = args
+//         .iter()
+//         .map(|arg| arg.as_ptr())
+//         .collect::<Vec<*const std::os::raw::c_char>>();
 
-    unsafe {
-        ffi::WasmEdge_Driver_UniTool(c_args.len() as std::os::raw::c_int, c_args.as_mut_ptr())
-    }
-}
+//     unsafe {
+//         ffi::WasmEdge_Driver_UniTool(c_args.len() as std::os::raw::c_int, c_args.as_mut_ptr())
+//     }
+// }


### PR DESCRIPTION
In this PR, add the `build_macos` and `build_fedora` jobs in the `standalone` workflow.