### PR TITLE
[feat] Implement `sock_getaddrinfo` in `wasmedge_sys::async_wasi`

### DIFF
--- a/.github/workflows/bindings-rust.yml
+++ b/.github/workflows/bindings-rust.yml
@@ -102,7 +102,7 @@ jobs:
 
   build_fedora:
     name: Fedora
-    runs-on: fedora-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         rust: [1.70.0, 1.69, 1.68]

--- a/.github/workflows/bindings-rust.yml
+++ b/.github/workflows/bindings-rust.yml
@@ -101,8 +101,8 @@ jobs:
           cargo test --workspace --locked --features aot,async,wasmedge_process,ffi -- --nocapture
 
   build_fedora:
-    name: Fedora latest
-    runs-on: Fedora-latest
+    name: Fedora
+    runs-on: fedora-latest
     strategy:
       matrix:
         rust: [1.70.0, 1.69, 1.68]

--- a/crates/async-wasi/src/snapshots/common/vfs/sync.rs
+++ b/crates/async-wasi/src/snapshots/common/vfs/sync.rs
@@ -671,8 +671,7 @@ impl WasiPreOpenDir {
 
     pub fn get_absolutize_path<P: AsRef<Path>>(&self, sub_path: &P) -> Result<PathBuf, Errno> {
         use path_absolutize::*;
-        let mut new_path = self.real_path.clone();
-        new_path.join(sub_path);
+        let new_path = self.real_path.join(sub_path);
         let absolutize = new_path
             .absolutize_virtually(&self.real_path)
             .or(Err(Errno::__WASI_ERRNO_NOENT))?;

--- a/crates/async-wasi/src/snapshots/preview_1/async_socket.rs
+++ b/crates/async-wasi/src/snapshots/preview_1/async_socket.rs
@@ -801,7 +801,7 @@ pub mod addrinfo {
         res_len: WasmPtr<u32>,
     ) -> Result<(), Errno> {
         use std::net::ToSocketAddrs;
-        if max_len <= 0 {
+        if max_len == 0 {
             return Err(Errno::__WASI_ERRNO_INVAL);
         }
         let node =

--- a/crates/async-wasi/src/snapshots/preview_1/async_socket.rs
+++ b/crates/async-wasi/src/snapshots/preview_1/async_socket.rs
@@ -750,7 +750,7 @@ pub async fn sock_lookup_ip<M: Memory>(
     }
 }
 
-mod addrinfo {
+pub mod addrinfo {
     use crate::snapshots::{
         common::memory::{Memory, WasmPtr},
         env::Errno,
@@ -840,5 +840,3 @@ mod addrinfo {
         Ok(())
     }
 }
-
-pub use addrinfo::sock_getaddrinfo;

--- a/crates/async-wasi/src/snapshots/preview_1/mod.rs
+++ b/crates/async-wasi/src/snapshots/preview_1/mod.rs
@@ -150,7 +150,7 @@ pub fn fd_prestat_get<M: Memory>(
     let fd = ctx.get_mut_vfd(fd)?;
     match fd {
         VFD::Inode(INode::PreOpenDir(dir)) => {
-            let path_str = dir.real_path.to_str().ok_or(Errno::__WASI_ERRNO_NOTSUP)?;
+            let path_str = dir.guest_path.to_str().ok_or(Errno::__WASI_ERRNO_NOTSUP)?;
             let pr_name_len = path_str.as_bytes().len() as u32;
 
             prestat.tag = __wasi_preopentype_t::__WASI_PREOPENTYPE_DIR;
@@ -173,7 +173,7 @@ pub fn fd_prestat_dir_name<M: Memory>(
     let fd = ctx.get_mut_vfd(fd)?;
     match fd {
         VFD::Inode(INode::PreOpenDir(dir)) => {
-            let path_str = dir.real_path.to_str().ok_or(Errno::__WASI_ERRNO_NOTSUP)?;
+            let path_str = dir.guest_path.to_str().ok_or(Errno::__WASI_ERRNO_NOTSUP)?;
             let path_bytes = path_str.as_bytes();
             let path_len = path_bytes.len();
 

--- a/crates/wasmedge-macro/Cargo.toml
+++ b/crates/wasmedge-macro/Cargo.toml
@@ -14,4 +14,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.43"
 quote = "1"
-syn = {version = "1.0", features = ["full", "extra-traits"]}
+syn = {version = "2.0.18", features = ["full", "extra-traits"]}

--- a/crates/wasmedge-macro/src/lib.rs
+++ b/crates/wasmedge-macro/src/lib.rs
@@ -229,14 +229,14 @@ fn sys_expand_host_func(item_fn: &syn::ItemFn) -> syn::Result<proc_macro2::Token
 }
 
 #[proc_macro_attribute]
-pub fn sys_async_host_function_new(_attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn sys_async_host_function(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let body_ast = parse_macro_input!(item as Item);
     if let Item::Fn(item_fn) = body_ast {
         if item_fn.sig.asyncness.is_none() {
             panic!("The function must be async");
         }
 
-        match sys_expand_async_host_func_new(&item_fn) {
+        match sys_expand_async_host_func(&item_fn) {
             Ok(token_stream) => token_stream.into(),
             Err(err) => err.to_compile_error().into(),
         }
@@ -245,19 +245,17 @@ pub fn sys_async_host_function_new(_attr: TokenStream, item: TokenStream) -> Tok
     }
 }
 
-fn sys_expand_async_host_func_new(item_fn: &syn::ItemFn) -> syn::Result<proc_macro2::TokenStream> {
+fn sys_expand_async_host_func(item_fn: &syn::ItemFn) -> syn::Result<proc_macro2::TokenStream> {
     // extract T from Option<&mut T>
     let ret = match &item_fn.sig.inputs.len() {
-        3 => sys_expand_async_host_func_with_three_args_new(item_fn),
+        3 => sys_expand_async_host_func_with_three_args(item_fn),
         _ => panic!("Invalid numbers of host function arguments"),
     };
 
     Ok(ret)
 }
 
-fn sys_expand_async_host_func_with_three_args_new(
-    item_fn: &syn::ItemFn,
-) -> proc_macro2::TokenStream {
+fn sys_expand_async_host_func_with_three_args(item_fn: &syn::ItemFn) -> proc_macro2::TokenStream {
     let fn_name_ident = &item_fn.sig.ident;
     let fn_visibility = &item_fn.vis;
 

--- a/crates/wasmedge-sys/src/async_wasi.rs
+++ b/crates/wasmedge-sys/src/async_wasi.rs
@@ -1498,7 +1498,6 @@ pub fn sock_getaddrinfo(
     args: Vec<WasmValue>,
     data: Option<&mut WasiCtx>,
 ) -> std::result::Result<Vec<WasmValue>, HostFuncError> {
-    let n = 8;
     let args: Vec<WasmVal> = args.into_iter().map(|v| v.into()).collect();
     let mut mem = if let Some(mem) = frame.memory_mut(0) {
         WasiMem(mem)
@@ -1509,7 +1508,7 @@ pub fn sock_getaddrinfo(
 
     if let Some(
         [WasmVal::I32(p1), WasmVal::I32(p2), WasmVal::I32(p3), WasmVal::I32(p4), WasmVal::I32(p5), WasmVal::I32(p6), WasmVal::I32(p7), WasmVal::I32(p8)],
-    ) = args.get(0..n)
+    ) = args.get(0..8)
     {
         let node = *p1 as usize;
         let node_len = *p2 as u32;
@@ -1533,7 +1532,7 @@ pub fn sock_getaddrinfo(
             WasmPtr::from(res_len),
         )))
     } else {
-        Err(func_type_miss_match_error())
+        Err(HostFuncError::Runtime(0x83))
     }
 }
 

--- a/crates/wasmedge-sys/src/async_wasi.rs
+++ b/crates/wasmedge-sys/src/async_wasi.rs
@@ -1498,7 +1498,6 @@ pub fn sock_getaddrinfo(
     args: Vec<WasmValue>,
     data: Option<&mut WasiCtx>,
 ) -> std::result::Result<Vec<WasmValue>, HostFuncError> {
-    log::trace!("sock_getaddrinfo enter");
     let n = 8;
     let args: Vec<WasmVal> = args.into_iter().map(|v| v.into()).collect();
     let mut mem = if let Some(mem) = frame.memory_mut(0) {
@@ -1521,7 +1520,7 @@ pub fn sock_getaddrinfo(
         let max_len = *p7 as u32;
         let res_len = *p8 as usize;
 
-        Ok(to_wasm_return(p::async_socket::sock_getaddrinfo(
+        Ok(to_wasm_return(p::async_socket::addrinfo::sock_getaddrinfo(
             data,
             &mut mem,
             WasmPtr::from(node),

--- a/crates/wasmedge-sys/src/async_wasi.rs
+++ b/crates/wasmedge-sys/src/async_wasi.rs
@@ -11,7 +11,7 @@ use wasi::snapshots::{
     },
     preview_1 as p, WasiCtx,
 };
-use wasmedge_macro::{sys_async_host_function_new, sys_host_function};
+use wasmedge_macro::{sys_async_host_function, sys_host_function};
 use wasmedge_types::{error::HostFuncError, ValType};
 
 fn to_wasm_return(r: Result<(), Errno>) -> Vec<WasmValue> {
@@ -1162,7 +1162,7 @@ pub fn sock_listen(
 pub type BoxedResultFuture =
     Box<dyn std::future::Future<Output = Result<Vec<WasmValue>, HostFuncError>> + Send>;
 
-#[sys_async_host_function_new]
+#[sys_async_host_function]
 pub async fn sock_accept(
     frame: CallingFrame,
     args: Vec<WasmValue>,
@@ -1184,7 +1184,7 @@ pub async fn sock_accept(
     }
 }
 
-#[sys_async_host_function_new]
+#[sys_async_host_function]
 pub async fn sock_connect(
     frame: CallingFrame,
     args: Vec<WasmValue>,
@@ -1207,7 +1207,7 @@ pub async fn sock_connect(
     }
 }
 
-#[sys_async_host_function_new]
+#[sys_async_host_function]
 pub async fn sock_recv(
     frame: CallingFrame,
     args: Vec<WasmValue>,
@@ -1243,7 +1243,7 @@ pub async fn sock_recv(
     }
 }
 
-#[sys_async_host_function_new]
+#[sys_async_host_function]
 pub async fn sock_recv_from(
     frame: CallingFrame,
     args: Vec<WasmValue>,
@@ -1283,7 +1283,7 @@ pub async fn sock_recv_from(
     }
 }
 
-#[sys_async_host_function_new]
+#[sys_async_host_function]
 pub async fn sock_send(
     frame: CallingFrame,
     args: Vec<WasmValue>,
@@ -1317,7 +1317,7 @@ pub async fn sock_send(
     }
 }
 
-#[sys_async_host_function_new]
+#[sys_async_host_function]
 pub async fn sock_send_to(
     frame: CallingFrame,
     args: Vec<WasmValue>,
@@ -1529,7 +1529,7 @@ pub fn sock_getaddrinfo(
     }
 }
 
-#[sys_async_host_function_new]
+#[sys_async_host_function]
 pub async fn poll_oneoff(
     frame: CallingFrame,
     args: Vec<WasmValue>,
@@ -1561,7 +1561,7 @@ pub async fn poll_oneoff(
     }
 }
 
-#[sys_async_host_function_new]
+#[sys_async_host_function]
 pub async fn sock_lookup_ip(
     frame: CallingFrame,
     args: Vec<WasmValue>,

--- a/crates/wasmedge-sys/src/executor.rs
+++ b/crates/wasmedge-sys/src/executor.rs
@@ -375,7 +375,7 @@ mod tests {
         thread,
     };
     #[cfg(all(feature = "async", target_os = "linux"))]
-    use wasmedge_macro::sys_async_host_function_new;
+    use wasmedge_macro::sys_async_host_function;
     use wasmedge_macro::sys_host_function;
     use wasmedge_types::{error::HostFuncError, Mutability, NeverType, RefType, ValType};
 
@@ -711,7 +711,7 @@ mod tests {
     }
 
     #[cfg(all(feature = "async", target_os = "linux"))]
-    #[sys_async_host_function_new]
+    #[sys_async_host_function]
     async fn async_hello<T>(
         _frame: CallingFrame,
         _inputs: Vec<WasmValue>,

--- a/crates/wasmedge-sys/src/instance/function.rs
+++ b/crates/wasmedge-sys/src/instance/function.rs
@@ -285,11 +285,11 @@ impl Function {
     /// ```rust
     /// use wasmedge_sys::{FuncType, Function, WasmValue, CallingFrame};
     /// use wasmedge_types::{error::HostFuncError, ValType, WasmEdgeResult, NeverType};
-    /// use wasmedge_macro::sys_async_host_function_new;
+    /// use wasmedge_macro::sys_async_host_function;
     /// use std::future::Future;
     /// use std::os::raw::c_void;
     ///
-    /// #[sys_async_host_function_new]
+    /// #[sys_async_host_function]
     /// async fn real_add<T>(
     ///     _frame: CallingFrame,
     ///     input: Vec<WasmValue>,

--- a/crates/wasmedge-sys/src/plugin.rs
+++ b/crates/wasmedge-sys/src/plugin.rs
@@ -277,7 +277,7 @@ pub struct ModuleDescriptor {
     name: CString,
     desc: CString,
     create: Option<ModuleInstanceCreateFn>,
-    pub inner: ffi::WasmEdge_ModuleDescriptor,
+    inner: ffi::WasmEdge_ModuleDescriptor,
 }
 impl ModuleDescriptor {
     /// Creates a new module descriptor.
@@ -307,6 +307,12 @@ impl ModuleDescriptor {
         md.inner.Create = md.create;
 
         Ok(md)
+    }
+
+    /// Returns the raw pointer to the inner `WasmEdge_ModuleDescriptor`.
+    #[cfg(feature = "ffi")]
+    pub fn as_raw_ptr(&self) -> *const ffi::WasmEdge_ModuleDescriptor {
+        &self.inner
     }
 }
 
@@ -354,7 +360,7 @@ pub struct PluginDescriptor {
     module_descriptors: Vec<ffi::WasmEdge_ModuleDescriptor>,
     program_options_name_desc: Vec<(CString, CString)>,
     program_options: Vec<ffi::WasmEdge_ProgramOption>,
-    pub inner: ffi::WasmEdge_PluginDescriptor,
+    inner: ffi::WasmEdge_PluginDescriptor,
 }
 impl PluginDescriptor {
     pub fn create(


### PR DESCRIPTION
In this PR, the following changes are introduced,

- Implements `sock_getaddrinfo` in `wasmedge_sys::async_wasi`.
- Refactors `ModuleDescriptor` and `PluginDescriptor` in `wasmedge-sys`.
- Improves `build_fedora` job in `bindings-rust` workflow.
- Renamed `sys_async_host_function_new` to `sys_async_host_function` in `wasmedge-macro`.