### PR TITLE
[feat] Support new c-apis

### DIFF
--- a/crates/wasmedge-sys/examples/func_call_across_different_modes.rs
+++ b/crates/wasmedge-sys/examples/func_call_across_different_modes.rs
@@ -47,7 +47,7 @@ fn interpreter_call_aot() -> Result<(), Box<dyn std::error::Error>> {
     let mut store = Store::create()?;
 
     // create an import module
-    let mut import = ImportModule::create("host")?;
+    let mut import = ImportModule::<NeverType>::create("host")?;
 
     // import host_print_i32 as a host function
     let func_ty = FuncType::create([ValType::I32], [])?;
@@ -132,7 +132,7 @@ fn aot_call_interpreter() -> Result<(), Box<dyn std::error::Error>> {
     let mut store = Store::create()?;
 
     // create an import module
-    let mut import = ImportModule::create("host")?;
+    let mut import = ImportModule::<NeverType>::create("host")?;
 
     // import host_print_i32 as a host function
     let func_ty = FuncType::create([ValType::I32], [])?;

--- a/crates/wasmedge-sys/examples/hostfunc.rs
+++ b/crates/wasmedge-sys/examples/hostfunc.rs
@@ -64,7 +64,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let host_func = Function::create::<NeverType>(&func_ty, real_add, None, 0)?;
 
     // create an ImportObject module
-    let mut import = ImportModule::create("extern_module")?;
+    let mut import = ImportModule::<NeverType>::create("extern_module")?;
     import.add_func("add", host_func);
 
     // create a config

--- a/crates/wasmedge-sys/examples/hostfunc2.rs
+++ b/crates/wasmedge-sys/examples/hostfunc2.rs
@@ -52,7 +52,7 @@ fn real_add<T>(
 #[cfg_attr(test, test)]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config = Config::create()?;
-    let mut import = ImportModule::create("extern_module")?;
+    let mut import = ImportModule::<NeverType>::create("extern_module")?;
 
     let result = FuncType::create(
         vec![ValType::ExternRef, ValType::I32, ValType::I32],

--- a/crates/wasmedge-sys/examples/table_and_funcref.rs
+++ b/crates/wasmedge-sys/examples/table_and_funcref.rs
@@ -57,7 +57,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     table.set_data(WasmValue::from_func_ref(host_func.as_ref()), 3)?;
 
     // add the table instance to the import object
-    let mut import = ImportModule::create("extern")?;
+    let mut import = ImportModule::<NeverType>::create("extern")?;
     import.add_table("my-table", table);
 
     // create a config

--- a/crates/wasmedge-sys/src/executor.rs
+++ b/crates/wasmedge-sys/src/executor.rs
@@ -66,10 +66,10 @@ impl Executor {
     /// # Error
     ///
     /// If fail to register the given [import object](crate::ImportObject), then an error is returned.
-    pub fn register_import_object(
+    pub fn register_import_object<T: Send + Sync + Clone>(
         &mut self,
         store: &mut Store,
-        import: &ImportObject,
+        import: &ImportObject<T>,
     ) -> WasmEdgeResult<()> {
         match import {
             ImportObject::Import(import) => unsafe {
@@ -446,7 +446,7 @@ mod tests {
         let host_name = "extern";
 
         // create an ImportObj module
-        let result = ImportModule::create(host_name);
+        let result = ImportModule::<NeverType>::create(host_name);
         assert!(result.is_ok());
         let mut import = result.unwrap();
 
@@ -597,7 +597,7 @@ mod tests {
         let async_wasi_module = result.unwrap();
 
         // register async_wasi module into the store
-        let wasi_import = ImportObject::AsyncWasi(async_wasi_module);
+        let wasi_import = ImportObject::<NeverType>::AsyncWasi(async_wasi_module);
         let result = executor.register_import_object(&mut store, &wasi_import);
         assert!(result.is_ok());
 
@@ -649,14 +649,13 @@ mod tests {
         let async_wasi_module = result.unwrap();
 
         // register async_wasi module into the store
-        let wasi_import = ImportObject::AsyncWasi(async_wasi_module);
+        let wasi_import = ImportObject::<NeverType>::AsyncWasi(async_wasi_module);
         let result = executor.register_import_object(&mut store, &wasi_import);
         assert!(result.is_ok());
 
-        // todo
         let ty = FuncType::create([], [])?;
         let async_hello_func = Function::create_async::<NeverType>(&ty, async_hello, None, 0)?;
-        let mut import = ImportModule::create("extern")?;
+        let mut import = ImportModule::<NeverType>::create("extern")?;
         import.add_func("async_hello", async_hello_func);
 
         let extern_import = ImportObject::Import(import);

--- a/crates/wasmedge-sys/src/instance/module.rs
+++ b/crates/wasmedge-sys/src/instance/module.rs
@@ -267,7 +267,7 @@ impl Instance {
     }
 
     /// Returns the host data held by the module instance.
-    pub fn host_data<T>(&self) -> Option<&mut T> {
+    pub fn host_data<T>(&mut self) -> Option<&mut T> {
         let ctx = unsafe { ffi::WasmEdge_ModuleInstanceGetHostData(self.inner.0) };
 
         match ctx.is_null() {
@@ -1912,7 +1912,7 @@ mod tests {
 
         let result = store.module(module_name);
         assert!(result.is_ok());
-        let instance = result.unwrap();
+        let mut instance = result.unwrap();
 
         // get the exported memory
         let result = instance.get_memory("mem");
@@ -2097,7 +2097,7 @@ mod tests {
 
         let result = store.module(module_name);
         assert!(result.is_ok());
-        let instance = result.unwrap();
+        let mut instance = result.unwrap();
 
         let result = instance.host_data::<Circle>();
         assert!(result.is_some());

--- a/crates/wasmedge-sys/src/instance/module.rs
+++ b/crates/wasmedge-sys/src/instance/module.rs
@@ -428,7 +428,7 @@ impl ImportModule {
     /// # Error
     ///
     /// If fail to create the import module instance, then an error is returned.
-    pub fn create_with_data<T>(
+    pub fn create_with_data<T: Send + Sync + Clone + 'static>(
         name: impl AsRef<str>,
         host_data: &mut T,
         finalizer: Option<Finalizer>,
@@ -2067,13 +2067,16 @@ mod tests {
         let module_name = "extern_module";
 
         // define host data
+        #[derive(Clone, Debug)]
         struct Circle {
             radius: i32,
         }
-        let mut circle = Circle { radius: 10 };
 
-        // create an import module
-        let result = ImportModule::create_with_data::<Circle>(module_name, &mut circle, None);
+        let result = {
+            let mut circle = Circle { radius: 10 };
+            // create an import module
+            ImportModule::create_with_data::<Circle>(module_name, &mut circle, None)
+        };
         assert!(result.is_ok());
         let import = result.unwrap();
 

--- a/crates/wasmedge-sys/src/instance/module.rs
+++ b/crates/wasmedge-sys/src/instance/module.rs
@@ -267,7 +267,7 @@ impl Instance {
     }
 
     /// Returns the host data held by the module instance.
-    pub fn host_data<T>(&mut self) -> Option<&mut T> {
+    pub fn host_data<T: Send + Sync + Clone>(&mut self) -> Option<&mut T> {
         let ctx = unsafe { ffi::WasmEdge_ModuleInstanceGetHostData(self.inner.0) };
 
         match ctx.is_null() {

--- a/crates/wasmedge-sys/src/lib.rs
+++ b/crates/wasmedge-sys/src/lib.rs
@@ -99,7 +99,7 @@ pub use instance::{
     function::{FuncRef, FuncType, Function, HostFn},
     global::{Global, GlobalType},
     memory::{MemType, Memory},
-    module::{AsImport, AsInstance, ImportModule, ImportObject, Instance},
+    module::{AsImport, AsInstance, Finalizer, ImportModule, ImportObject, Instance},
     table::{Table, TableType},
 };
 #[doc(inline)]

--- a/crates/wasmedge-sys/src/store.rs
+++ b/crates/wasmedge-sys/src/store.rs
@@ -153,7 +153,7 @@ mod tests {
         assert!(store.module_names().is_none());
 
         // create ImportObject instance
-        let result = ImportModule::create(module_name);
+        let result = ImportModule::<NeverType>::create(module_name);
         assert!(result.is_ok());
         let mut import = result.unwrap();
 
@@ -239,7 +239,7 @@ mod tests {
         let store_cloned = Arc::clone(&store);
         let handle = thread::spawn(move || {
             // create ImportObject instance
-            let result = ImportModule::create("extern_module");
+            let result = ImportModule::<NeverType>::create("extern_module");
             assert!(result.is_ok());
             let mut import = result.unwrap();
 

--- a/crates/wasmedge-sys/tests/common.rs
+++ b/crates/wasmedge-sys/tests/common.rs
@@ -2,7 +2,7 @@ use wasmedge_macro::sys_host_function;
 use wasmedge_sys::{AsImport, CallingFrame, FuncType, Function, ImportModule, WasmValue};
 use wasmedge_types::{error::HostFuncError, NeverType, ValType};
 
-pub fn create_extern_module(name: impl AsRef<str>) -> ImportModule {
+pub fn create_extern_module(name: impl AsRef<str>) -> ImportModule<NeverType> {
     // create an import module
     let result = ImportModule::create(name);
     assert!(result.is_ok());

--- a/crates/wasmedge-sys/tests/test_aot.rs
+++ b/crates/wasmedge-sys/tests/test_aot.rs
@@ -86,7 +86,7 @@ fn test_aot() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[cfg(feature = "aot")]
-fn create_spec_test_module() -> ImportModule {
+fn create_spec_test_module() -> ImportModule<NeverType> {
     // create an ImportObj module
     let result = ImportModule::create("spectest");
     assert!(result.is_ok());

--- a/crates/wasmedge-types/src/lib.rs
+++ b/crates/wasmedge-types/src/lib.rs
@@ -576,4 +576,7 @@ pub use wat::parse_bytes as wat2wasm;
 pub type WasmEdgeResult<T> = Result<T, Box<error::WasmEdgeError>>;
 
 /// This is a workaround solution to the [`never`](https://doc.rust-lang.org/std/primitive.never.html) type in Rust. It will be replaced by `!` once it is stable.
+#[derive(Debug, Clone)]
 pub enum NeverType {}
+unsafe impl Send for NeverType {}
+unsafe impl Sync for NeverType {}

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -97,7 +97,7 @@ mod tests {
     use super::*;
     use crate::{
         config::{CompilerConfigOptions, ConfigBuilder},
-        params, wat2wasm, CompilerOutputFormat, VmBuilder, WasmVal,
+        params, wat2wasm, CompilerOutputFormat, NeverType, VmBuilder, WasmVal,
     };
     use std::io::Read;
 
@@ -133,10 +133,11 @@ mod tests {
             let wasm_magic: [u8; 4] = [0x00, 0x61, 0x73, 0x6D];
             assert_ne!(buffer, wasm_magic);
 
-            let res =
-                VmBuilder::new()
-                    .build()?
-                    .run_func_from_file(&aot_file_path, "fib", params!(5))?;
+            let res = VmBuilder::new().build::<NeverType>()?.run_func_from_file(
+                &aot_file_path,
+                "fib",
+                params!(5),
+            )?;
             assert_eq!(res[0].to_i32(), 8);
 
             // cleanup
@@ -206,10 +207,11 @@ mod tests {
             let wasm_magic: [u8; 4] = [0x00, 0x61, 0x73, 0x6D];
             assert_ne!(buffer, wasm_magic);
 
-            let res =
-                VmBuilder::new()
-                    .build()?
-                    .run_func_from_file(&aot_file_path, "fib", params!(5))?;
+            let res = VmBuilder::new().build::<NeverType>()?.run_func_from_file(
+                &aot_file_path,
+                "fib",
+                params!(5),
+            )?;
             assert_eq!(res[0].to_i32(), 8);
 
             // cleanup

--- a/src/dock.rs
+++ b/src/dock.rs
@@ -7,17 +7,17 @@ use std::any::Any;
 
 /// Extends a [Vm](crate::Vm) instance by supporting function arguments of Rust built-in types.
 #[derive(Debug)]
-pub struct VmDock {
-    pub(crate) vm: Box<Vm>, // Can't use Arc because vm can be get_mut after cloned for hostfunc
+pub struct VmDock<T: Send + Sync + Clone> {
+    pub(crate) vm: Box<Vm<T>>, // Can't use Arc because vm can be get_mut after cloned for hostfunc
 }
-impl VmDock {
+impl<T: Send + Sync + Clone> VmDock<T> {
     /// Creates a new [VmDock] to be associated with the given [Vm](crate::Vm).
     ///
     /// # Arguments
     ///
     /// * `vm` - The [Vm] instance to be extended.
     ///
-    pub fn new(vm: Vm) -> Self {
+    pub fn new(vm: Vm<T>) -> Self {
         VmDock { vm: Box::new(vm) }
     }
 
@@ -251,8 +251,8 @@ impl VmDock {
         self.vm.run_func(mod_name, "deallocate", args)
     }
 }
-unsafe impl Send for VmDock {}
-unsafe impl Sync for VmDock {}
+unsafe impl<T: Send + Sync + Clone> Send for VmDock<T> {}
+unsafe impl<T: Send + Sync + Clone> Sync for VmDock<T> {}
 
 /// Defines a type container that wraps a value of Rust built-in type.
 #[derive(Debug)]
@@ -279,7 +279,11 @@ pub enum Param<'a> {
     String(&'a str),
 }
 impl<'a> Param<'a> {
-    fn settle(&self, vm: &VmDock, mem: &mut Memory) -> WasmEdgeResult<(i32, i32)> {
+    fn settle<T: Send + Sync + Clone>(
+        &self,
+        vm: &VmDock<T>,
+        mem: &mut Memory,
+    ) -> WasmEdgeResult<(i32, i32)> {
         match self {
             Param::I8(v) => {
                 let length = 1;
@@ -467,7 +471,7 @@ impl<'a> Param<'a> {
         }
     }
 
-    fn allocate(dock: &VmDock, size: i32) -> WasmEdgeResult<i32> {
+    fn allocate<T: Send + Sync + Clone>(dock: &VmDock<T>, size: i32) -> WasmEdgeResult<i32> {
         let res = dock.vm.run_func(None, "allocate", params!(size))?;
 
         Ok(res[0].to_i32())

--- a/src/externals/function.rs
+++ b/src/externals/function.rs
@@ -413,8 +413,8 @@ mod tests {
     #[allow(clippy::assertions_on_result_states)]
     fn test_func_basic() {
         // create an ImportModule
-        let result = ImportObjectBuilder::new()
-            .with_func::<(i32, i32), i32, NeverType>("add", real_add, None)
+        let result = ImportObjectBuilder::<NeverType>::new()
+            .with_func::<(i32, i32), i32>("add", real_add, None)
             .expect("failed to add host func")
             .build("extern");
         assert!(result.is_ok());

--- a/src/externals/global.rs
+++ b/src/externals/global.rs
@@ -86,7 +86,7 @@ mod tests {
     use crate::{
         config::{CommonConfigOptions, ConfigBuilder},
         error::{GlobalError, WasmEdgeError},
-        Executor, ImportObjectBuilder, Mutability, Statistics, Store, ValType,
+        Executor, ImportObjectBuilder, Mutability, NeverType, Statistics, Store, ValType,
     };
 
     #[test]
@@ -120,11 +120,9 @@ mod tests {
         let global_var = result.unwrap();
 
         // create an import object
-        let result = ImportObjectBuilder::new()
+        let result = ImportObjectBuilder::<NeverType>::new()
             .with_global("const-global", global_const)
-            .expect("failed to add const-global")
             .with_global("var-global", global_var)
-            .expect("failed to add var-global")
             .build("extern");
         assert!(result.is_ok());
         let import = result.unwrap();

--- a/src/externals/memory.rs
+++ b/src/externals/memory.rs
@@ -169,7 +169,7 @@ mod tests {
     use super::*;
     use crate::{
         config::{CommonConfigOptions, ConfigBuilder},
-        Executor, ImportObjectBuilder, Statistics, Store,
+        Executor, ImportObjectBuilder, NeverType, Statistics, Store,
     };
 
     #[test]
@@ -200,9 +200,8 @@ mod tests {
         let memory = result.unwrap();
 
         // create an import object
-        let result = ImportObjectBuilder::new()
+        let result = ImportObjectBuilder::<NeverType>::new()
             .with_memory("memory", memory)
-            .expect("failed to add memory")
             .build("extern");
         assert!(result.is_ok());
         let import = result.unwrap();

--- a/src/externals/table.rs
+++ b/src/externals/table.rs
@@ -150,11 +150,10 @@ mod tests {
         let table = result.unwrap();
 
         // create an import object
-        let result = ImportObjectBuilder::new()
-            .with_func::<(i32, i32), i32, NeverType>("add", real_add, None)
+        let result = ImportObjectBuilder::<NeverType>::new()
+            .with_func::<(i32, i32), i32>("add", real_add, None)
             .expect("failed to add host func")
             .with_table("table", table)
-            .expect("failed to add table")
             .build("extern");
         assert!(result.is_ok());
         let import = result.unwrap();

--- a/src/import.rs
+++ b/src/import.rs
@@ -398,10 +398,10 @@ mod tests {
         // register an import module into vm
         let result = vm.register_import_module(import);
         assert!(result.is_ok());
-        let vm = result.unwrap();
+        let mut vm = result.unwrap();
 
         // get active module instance
-        let result = vm.named_module("extern");
+        let result = vm.named_module_mut("extern");
         assert!(result.is_ok());
         let instance = result.unwrap();
 

--- a/src/import.rs
+++ b/src/import.rs
@@ -288,7 +288,7 @@ impl ImportObjectBuilder {
     /// # Error
     ///
     /// If fail to create the [ImportObject], then an error is returned.
-    pub fn build_with_data<T>(
+    pub fn build_with_data<T: Send + Sync + Clone + 'static>(
         self,
         name: impl AsRef<str>,
         host_data: &mut T,
@@ -377,12 +377,15 @@ mod tests {
     #[allow(clippy::assertions_on_result_states)]
     fn test_import_builder_with_data() {
         // define host data
+        #[derive(Clone)]
         struct Circle {
             radius: i32,
         }
-        let mut circle = Circle { radius: 10 };
 
-        let result = ImportObjectBuilder::default().build_with_data("extern", &mut circle, None);
+        let result = {
+            let mut circle = Circle { radius: 10 };
+            ImportObjectBuilder::default().build_with_data("extern", &mut circle, None)
+        };
         assert!(result.is_ok());
         let import = result.unwrap();
         assert_eq!(import.name(), "extern");

--- a/src/import.rs
+++ b/src/import.rs
@@ -78,7 +78,7 @@ use wasmedge_sys::{self as sys, AsImport};
 /// ```
 /// [[Click for more examples]](https://github.com/WasmEdge/WasmEdge/tree/master/bindings/rust/wasmedge/examples)
 ///
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ImportObjectBuilder<T: Send + Sync + Clone> {
     funcs: Vec<(String, sys::Function)>,
     globals: Vec<(String, sys::Global)>,

--- a/src/import.rs
+++ b/src/import.rs
@@ -1,6 +1,8 @@
 #[cfg(all(feature = "async", target_os = "linux"))]
 use crate::r#async::AsyncHostFn;
-use crate::{io::WasmValTypeList, FuncType, Global, HostFn, Memory, Table, WasmEdgeResult, Finalizer};
+use crate::{
+    io::WasmValTypeList, Finalizer, FuncType, Global, HostFn, Memory, Table, WasmEdgeResult,
+};
 use wasmedge_sys::{self as sys, AsImport};
 
 /// Creates a normal or wasi [import object](crate::ImportObject).
@@ -278,9 +280,9 @@ impl ImportObjectBuilder {
     /// # Argument
     ///
     /// * `name` - The name of the [ImportObject] to create.
-    /// 
+    ///
     /// * `host_data` - The host data to be stored in the module instance.
-    /// 
+    ///
     /// * `finalizer` - the function to drop the host data.
     ///
     /// # Error
@@ -355,7 +357,7 @@ mod tests {
         params,
         types::Val,
         CallingFrame, Executor, Global, GlobalType, Memory, MemoryType, Mutability, NeverType,
-        RefType, Statistics, Store, Table, TableType, ValType, WasmVal, WasmValue, VmBuilder,
+        RefType, Statistics, Store, Table, TableType, ValType, VmBuilder, WasmVal, WasmValue,
     };
     use std::{
         sync::{Arc, Mutex},

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -129,7 +129,7 @@ impl Instance {
     }
 
     /// Returns the host data held by the module instance.
-    pub fn host_data<T>(&mut self) -> Option<&mut T> {
+    pub fn host_data<T: Send + Sync + Clone>(&mut self) -> Option<&mut T> {
         self.inner.host_data()
     }
 }

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -129,7 +129,7 @@ impl Instance {
     }
 
     /// Returns the host data held by the module instance.
-    pub fn host_data<T>(&self) -> Option<&mut T> {
+    pub fn host_data<T>(&mut self) -> Option<&mut T> {
         self.inner.host_data()
     }
 }

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -251,15 +251,12 @@ mod tests {
         let table = result.unwrap();
 
         // create an ImportModule instance
-        let result = ImportObjectBuilder::new()
-            .with_func::<(i32, i32), i32, NeverType>("add", real_add, None)
+        let result = ImportObjectBuilder::<NeverType>::new()
+            .with_func::<(i32, i32), i32>("add", real_add, None)
             .expect("failed to add host function")
             .with_global("global", global_const)
-            .expect("failed to add const global")
             .with_memory("mem", memory)
-            .expect("failed to add memory")
             .with_table("table", table)
-            .expect("failed to add table")
             .build("extern-module");
         assert!(result.is_ok());
         let import = result.unwrap();

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -127,6 +127,11 @@ impl Instance {
             ty,
         })
     }
+
+    /// Returns the host data held by the module instance.
+    pub fn host_data<T>(&self) -> Option<&mut T> {
+        self.inner.host_data()
+    }
 }
 
 /// The object used as an module instance is required to implement this trait.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,8 +56,8 @@
 //!      #[cfg(not(feature = "async"))]
 //!      {
 //!          // create an import module
-//!          let import = ImportObjectBuilder::new()
-//!              .with_func::<(), (), NeverType>("say_hello", say_hello, None)?
+//!          let import = ImportObjectBuilder::<NeverType>::new()
+//!              .with_func::<(), ()>("say_hello", say_hello, None)?
 //!              .build("env")?;
 //!      
 //!          let wasm_bytes = wat2wasm(
@@ -83,7 +83,7 @@
 //!      
 //!          // create an executor
 //!          VmBuilder::new()
-//!              .build()?
+//!              .build::<NeverType>()?
 //!              .register_import_module(import)?
 //!              .register_module(Some("extern"), module)?
 //!              .run_func(Some("extern"), "run", params!())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,8 @@ pub type CallingFrame = wasmedge_sys::CallingFrame;
 
 pub type HostFn<T> = wasmedge_sys::HostFn<T>;
 
+pub type Finalizer = wasmedge_sys::Finalizer;
+
 #[cfg(all(feature = "async", target_os = "linux"))]
 pub mod r#async {
     pub type AsyncState = wasmedge_sys::r#async::AsyncState;

--- a/src/store.rs
+++ b/src/store.rs
@@ -30,10 +30,10 @@ impl Store {
     /// # Error
     ///
     /// If fail to register the given [import object](crate::ImportObject), then an error is returned.
-    pub fn register_import_module(
+    pub fn register_import_module<T: Send + Sync + Clone>(
         &mut self,
         executor: &mut Executor,
-        import: &ImportObject,
+        import: &ImportObject<T>,
     ) -> WasmEdgeResult<()> {
         executor
             .inner
@@ -188,15 +188,12 @@ mod tests {
         let table = result.unwrap();
 
         // create an ImportModule instance
-        let result = ImportObjectBuilder::new()
-            .with_func::<(i32, i32), i32, NeverType>("add", real_add, None)
+        let result = ImportObjectBuilder::<NeverType>::new()
+            .with_func::<(i32, i32), i32>("add", real_add, None)
             .expect("failed to add host function")
             .with_global("global", global_const)
-            .expect("failed to add const global")
             .with_memory("mem", memory)
-            .expect("failed to add memory")
             .with_table("table", table)
-            .expect("failed to add table")
             .build("extern-module");
         assert!(result.is_ok());
         let import = result.unwrap();
@@ -369,15 +366,12 @@ mod tests {
         let table = result.unwrap();
 
         // create an ImportModule instance
-        let result = ImportObjectBuilder::new()
-            .with_func::<(i32, i32), i32, NeverType>("add", real_add, None)
+        let result = ImportObjectBuilder::<NeverType>::new()
+            .with_func::<(i32, i32), i32>("add", real_add, None)
             .expect("failed to add host function")
             .with_global("global", global_const)
-            .expect("failed to add const global")
             .with_memory("mem", memory)
-            .expect("failed to add memory")
             .with_table("table", table)
-            .expect("failed to add table")
             .build("extern-module");
         assert!(result.is_ok());
         let import = result.unwrap();


### PR DESCRIPTION
In this PR, the new c-apis below are supported:

- `WasmEdge_ModuleInstanceCreateWithData`
- `WasmEdge_ModuleInstanceGetHostData`