### PR TITLE
[feat] Introduce `PluginModule` and `PluginModuleBuilder`

### DIFF
--- a/crates/wasmedge-sys/examples/func_call_across_different_modes.rs
+++ b/crates/wasmedge-sys/examples/func_call_across_different_modes.rs
@@ -47,7 +47,7 @@ fn interpreter_call_aot() -> Result<(), Box<dyn std::error::Error>> {
     let mut store = Store::create()?;
 
     // create an import module
-    let mut import = ImportModule::<NeverType>::create("host")?;
+    let mut import = ImportModule::<NeverType>::create("host", None)?;
 
     // import host_print_i32 as a host function
     let func_ty = FuncType::create([ValType::I32], [])?;
@@ -132,7 +132,7 @@ fn aot_call_interpreter() -> Result<(), Box<dyn std::error::Error>> {
     let mut store = Store::create()?;
 
     // create an import module
-    let mut import = ImportModule::<NeverType>::create("host")?;
+    let mut import = ImportModule::<NeverType>::create("host", None)?;
 
     // import host_print_i32 as a host function
     let func_ty = FuncType::create([ValType::I32], [])?;

--- a/crates/wasmedge-sys/examples/hostfunc.rs
+++ b/crates/wasmedge-sys/examples/hostfunc.rs
@@ -64,7 +64,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let host_func = Function::create::<NeverType>(&func_ty, real_add, None, 0)?;
 
     // create an ImportObject module
-    let mut import = ImportModule::<NeverType>::create("extern_module")?;
+    let mut import = ImportModule::<NeverType>::create("extern_module", None)?;
     import.add_func("add", host_func);
 
     // create a config

--- a/crates/wasmedge-sys/examples/hostfunc2.rs
+++ b/crates/wasmedge-sys/examples/hostfunc2.rs
@@ -52,7 +52,7 @@ fn real_add<T>(
 #[cfg_attr(test, test)]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config = Config::create()?;
-    let mut import = ImportModule::<NeverType>::create("extern_module")?;
+    let mut import = ImportModule::<NeverType>::create("extern_module", None)?;
 
     let result = FuncType::create(
         vec![ValType::ExternRef, ValType::I32, ValType::I32],

--- a/crates/wasmedge-sys/examples/table_and_funcref.rs
+++ b/crates/wasmedge-sys/examples/table_and_funcref.rs
@@ -57,7 +57,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     table.set_data(WasmValue::from_func_ref(host_func.as_ref()), 3)?;
 
     // add the table instance to the import object
-    let mut import = ImportModule::<NeverType>::create("extern")?;
+    let mut import = ImportModule::<NeverType>::create("extern", None)?;
     import.add_table("my-table", table);
 
     // create a config

--- a/crates/wasmedge-sys/src/executor.rs
+++ b/crates/wasmedge-sys/src/executor.rs
@@ -446,7 +446,7 @@ mod tests {
         let host_name = "extern";
 
         // create an ImportObj module
-        let result = ImportModule::<NeverType>::create(host_name);
+        let result = ImportModule::<NeverType>::create(host_name, None);
         assert!(result.is_ok());
         let mut import = result.unwrap();
 
@@ -655,7 +655,7 @@ mod tests {
 
         let ty = FuncType::create([], [])?;
         let async_hello_func = Function::create_async::<NeverType>(&ty, async_hello, None, 0)?;
-        let mut import = ImportModule::<NeverType>::create("extern")?;
+        let mut import = ImportModule::<NeverType>::create("extern", None)?;
         import.add_func("async_hello", async_hello_func);
 
         let extern_import = ImportObject::Import(import);

--- a/crates/wasmedge-sys/src/lib.rs
+++ b/crates/wasmedge-sys/src/lib.rs
@@ -99,7 +99,7 @@ pub use instance::{
     function::{FuncRef, FuncType, Function, HostFn},
     global::{Global, GlobalType},
     memory::{MemType, Memory},
-    module::{AsImport, AsInstance, Finalizer, ImportModule, ImportObject, Instance},
+    module::{AsImport, AsInstance, ImportModule, ImportObject, Instance},
     table::{Table, TableType},
 };
 #[doc(inline)]

--- a/crates/wasmedge-sys/src/plugin.rs
+++ b/crates/wasmedge-sys/src/plugin.rs
@@ -2,10 +2,12 @@
 
 use super::ffi;
 use crate::{
-    error::WasmEdgeError, instance::module::InnerInstance, types::WasmEdgeString, utils, Instance,
-    WasmEdgeResult,
+    error::{InstanceError, WasmEdgeError},
+    instance::{module::InnerInstance, Function, Global, Memory, Table},
+    types::WasmEdgeString,
+    utils, AsImport, Instance, WasmEdgeResult,
 };
-use std::ffi::CString;
+use std::{ffi::CString, os::raw::c_void, sync::Arc};
 
 /// Defines the APIs for loading plugins and check the basic information of the loaded plugins.
 #[derive(Debug)]
@@ -453,6 +455,127 @@ impl PluginDescriptor {
     #[cfg(feature = "ffi")]
     pub fn as_raw_ptr(&self) -> *const ffi::WasmEdge_PluginDescriptor {
         &self.inner
+    }
+}
+
+/// The finalizer funtion used to free the host data.
+pub type Finalizer = unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void);
+
+/// Represents a Plugin module instance.
+#[derive(Debug, Clone)]
+pub struct PluginModule<T: Send + Sync + Clone> {
+    pub(crate) inner: Arc<InnerInstance>,
+    pub(crate) registered: bool,
+    name: String,
+    _host_data: Option<Box<T>>,
+}
+impl<T: Send + Sync + Clone> Drop for PluginModule<T> {
+    fn drop(&mut self) {
+        if !self.registered && Arc::strong_count(&self.inner) == 1 && !self.inner.0.is_null() {
+            unsafe {
+                ffi::WasmEdge_ModuleInstanceDelete(self.inner.0);
+            }
+        }
+    }
+}
+impl<T: Send + Sync + Clone> PluginModule<T> {
+    /// Creates a module instance which is used to import host functions, tables, memories, and globals into a wasm module.
+    ///
+    /// # Argument
+    ///
+    /// * `name` - The name of the import module instance.
+    ///
+    /// * `host_data` - The host data to be stored in the module instance.
+    ///
+    /// * `finalizer` - the function to drop the host data. This argument is only available when `host_data` is set.
+    ///
+    /// # Error
+    ///
+    /// If fail to create the import module instance, then an error is returned.
+    pub fn create(
+        name: impl AsRef<str>,
+        mut host_data: Option<Box<T>>,
+        finalizer: Option<Finalizer>,
+    ) -> WasmEdgeResult<Self> {
+        let raw_name = WasmEdgeString::from(name.as_ref());
+
+        let ctx = match host_data.as_mut() {
+            Some(data) => unsafe {
+                ffi::WasmEdge_ModuleInstanceCreateWithData(
+                    raw_name.as_raw(),
+                    data.as_mut() as *mut T as *mut c_void,
+                    finalizer,
+                )
+            },
+            None => unsafe { ffi::WasmEdge_ModuleInstanceCreate(raw_name.as_raw()) },
+        };
+
+        match ctx.is_null() {
+            true => Err(Box::new(WasmEdgeError::Instance(
+                InstanceError::CreateImportModule,
+            ))),
+            false => match host_data.is_some() {
+                true => Ok(Self {
+                    inner: std::sync::Arc::new(InnerInstance(ctx)),
+                    registered: false,
+                    name: name.as_ref().to_string(),
+                    _host_data: host_data,
+                }),
+                false => Ok(Self {
+                    inner: std::sync::Arc::new(InnerInstance(ctx)),
+                    registered: false,
+                    name: name.as_ref().to_string(),
+                    _host_data: None,
+                }),
+            },
+        }
+    }
+
+    /// Provides a raw pointer to the inner module instance context.
+    #[cfg(feature = "ffi")]
+    pub fn as_raw_ptr(&self) -> *const ffi::WasmEdge_ModuleInstanceContext {
+        self.inner.0 as *const _
+    }
+}
+impl<T: Send + Sync + Clone> AsImport for PluginModule<T> {
+    fn name(&self) -> &str {
+        self.name.as_str()
+    }
+
+    fn add_func(&mut self, name: impl AsRef<str>, mut func: Function) {
+        let func_name: WasmEdgeString = name.into();
+        unsafe {
+            ffi::WasmEdge_ModuleInstanceAddFunction(self.inner.0, func_name.as_raw(), func.inner.0);
+        }
+        func.registered = true;
+    }
+
+    fn add_table(&mut self, name: impl AsRef<str>, mut table: Table) {
+        let table_name: WasmEdgeString = name.as_ref().into();
+        unsafe {
+            ffi::WasmEdge_ModuleInstanceAddTable(self.inner.0, table_name.as_raw(), table.inner.0);
+        }
+        table.registered = true;
+    }
+
+    fn add_memory(&mut self, name: impl AsRef<str>, mut memory: Memory) {
+        let mem_name: WasmEdgeString = name.as_ref().into();
+        unsafe {
+            ffi::WasmEdge_ModuleInstanceAddMemory(self.inner.0, mem_name.as_raw(), memory.inner.0);
+        }
+        memory.registered = true;
+    }
+
+    fn add_global(&mut self, name: impl AsRef<str>, mut global: Global) {
+        let global_name: WasmEdgeString = name.as_ref().into();
+        unsafe {
+            ffi::WasmEdge_ModuleInstanceAddGlobal(
+                self.inner.0,
+                global_name.as_raw(),
+                global.inner.0,
+            );
+        }
+        global.registered = true;
     }
 }
 

--- a/crates/wasmedge-sys/src/plugin.rs
+++ b/crates/wasmedge-sys/src/plugin.rs
@@ -514,20 +514,12 @@ impl<T: Send + Sync + Clone> PluginModule<T> {
             true => Err(Box::new(WasmEdgeError::Instance(
                 InstanceError::CreateImportModule,
             ))),
-            false => match host_data.is_some() {
-                true => Ok(Self {
-                    inner: std::sync::Arc::new(InnerInstance(ctx)),
-                    registered: false,
-                    name: name.as_ref().to_string(),
-                    _host_data: host_data,
-                }),
-                false => Ok(Self {
-                    inner: std::sync::Arc::new(InnerInstance(ctx)),
-                    registered: false,
-                    name: name.as_ref().to_string(),
-                    _host_data: None,
-                }),
-            },
+            false => Ok(Self {
+                inner: std::sync::Arc::new(InnerInstance(ctx)),
+                registered: false,
+                name: name.as_ref().to_string(),
+                _host_data: host_data,
+            }),
         }
     }
 

--- a/crates/wasmedge-sys/src/store.rs
+++ b/crates/wasmedge-sys/src/store.rs
@@ -153,7 +153,7 @@ mod tests {
         assert!(store.module_names().is_none());
 
         // create ImportObject instance
-        let result = ImportModule::<NeverType>::create(module_name);
+        let result = ImportModule::<NeverType>::create(module_name, None);
         assert!(result.is_ok());
         let mut import = result.unwrap();
 
@@ -239,7 +239,7 @@ mod tests {
         let store_cloned = Arc::clone(&store);
         let handle = thread::spawn(move || {
             // create ImportObject instance
-            let result = ImportModule::<NeverType>::create("extern_module");
+            let result = ImportModule::<NeverType>::create("extern_module", None);
             assert!(result.is_ok());
             let mut import = result.unwrap();
 

--- a/crates/wasmedge-sys/tests/common.rs
+++ b/crates/wasmedge-sys/tests/common.rs
@@ -4,7 +4,7 @@ use wasmedge_types::{error::HostFuncError, NeverType, ValType};
 
 pub fn create_extern_module(name: impl AsRef<str>) -> ImportModule<NeverType> {
     // create an import module
-    let result = ImportModule::create(name);
+    let result = ImportModule::<NeverType>::create(name, None);
     assert!(result.is_ok());
     let mut import = result.unwrap();
 

--- a/crates/wasmedge-sys/tests/test_aot.rs
+++ b/crates/wasmedge-sys/tests/test_aot.rs
@@ -3,7 +3,8 @@ use wasmedge_macro::sys_host_function;
 #[cfg(feature = "aot")]
 use wasmedge_sys::{
     AsImport, CallingFrame, Compiler, Config, Executor, FuncType, Function, ImportModule,
-    ImportObject, Loader, Store, Validator, WasmValue};
+    ImportObject, Loader, Store, Validator, WasmValue,
+};
 #[cfg(feature = "aot")]
 use wasmedge_types::{
     error::HostFuncError, CompilerOptimizationLevel, CompilerOutputFormat, NeverType,

--- a/crates/wasmedge-sys/tests/test_aot.rs
+++ b/crates/wasmedge-sys/tests/test_aot.rs
@@ -3,8 +3,7 @@ use wasmedge_macro::sys_host_function;
 #[cfg(feature = "aot")]
 use wasmedge_sys::{
     AsImport, CallingFrame, Compiler, Config, Executor, FuncType, Function, ImportModule,
-    ImportObject, Loader, Store, Validator, WasmValue,
-};
+    ImportObject, Loader, Store, Validator, WasmValue};
 #[cfg(feature = "aot")]
 use wasmedge_types::{
     error::HostFuncError, CompilerOptimizationLevel, CompilerOutputFormat, NeverType,
@@ -88,7 +87,7 @@ fn test_aot() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(feature = "aot")]
 fn create_spec_test_module() -> ImportModule<NeverType> {
     // create an ImportObj module
-    let result = ImportModule::create("spectest");
+    let result = ImportModule::<NeverType>::create("spectest", None);
     assert!(result.is_ok());
     let mut import = result.unwrap();
 

--- a/src/externals/function.rs
+++ b/src/externals/function.rs
@@ -414,7 +414,7 @@ mod tests {
     fn test_func_basic() {
         // create an ImportModule
         let result = ImportObjectBuilder::<NeverType>::new()
-            .with_func::<(i32, i32), i32>("add", real_add, None)
+            .with_func::<(i32, i32), i32>("add", real_add)
             .expect("failed to add host func")
             .build("extern");
         assert!(result.is_ok());

--- a/src/externals/table.rs
+++ b/src/externals/table.rs
@@ -151,7 +151,7 @@ mod tests {
 
         // create an import object
         let result = ImportObjectBuilder::<NeverType>::new()
-            .with_func::<(i32, i32), i32>("add", real_add, None)
+            .with_func::<(i32, i32), i32>("add", real_add)
             .expect("failed to add host func")
             .with_table("table", table)
             .build("extern");

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -252,7 +252,7 @@ mod tests {
 
         // create an ImportModule instance
         let result = ImportObjectBuilder::<NeverType>::new()
-            .with_func::<(i32, i32), i32>("add", real_add, None)
+            .with_func::<(i32, i32), i32>("add", real_add)
             .expect("failed to add host function")
             .with_global("global", global_const)
             .with_memory("mem", memory)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@
 //!      {
 //!          // create an import module
 //!          let import = ImportObjectBuilder::<NeverType>::new()
-//!              .with_func::<(), ()>("say_hello", say_hello, None)?
+//!              .with_func::<(), ()>("say_hello", say_hello)?
 //!              .build("env")?;
 //!      
 //!          let wasm_bytes = wat2wasm(
@@ -165,7 +165,7 @@ pub type CallingFrame = wasmedge_sys::CallingFrame;
 
 pub type HostFn<T> = wasmedge_sys::HostFn<T>;
 
-pub type Finalizer = wasmedge_sys::Finalizer;
+pub type Finalizer = wasmedge_sys::plugin::Finalizer;
 
 #[cfg(all(feature = "async", target_os = "linux"))]
 pub mod r#async {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -369,7 +369,8 @@ impl<T: Send + Sync + Clone> PluginModuleBuilder<T> {
     ///
     /// If fail to create the [PluginModule], then an error is returned.
     pub fn build(self, name: impl AsRef<str>) -> WasmEdgeResult<PluginModule<T>> {
-        let mut inner = sys::plugin::PluginModule::create(name.as_ref(), self.host_data, self.finalizer)?;
+        let mut inner =
+            sys::plugin::PluginModule::create(name.as_ref(), self.host_data, self.finalizer)?;
 
         // add func
         for (name, func) in self.funcs.into_iter() {

--- a/src/store.rs
+++ b/src/store.rs
@@ -189,7 +189,7 @@ mod tests {
 
         // create an ImportModule instance
         let result = ImportObjectBuilder::<NeverType>::new()
-            .with_func::<(i32, i32), i32>("add", real_add, None)
+            .with_func::<(i32, i32), i32>("add", real_add)
             .expect("failed to add host function")
             .with_global("global", global_const)
             .with_memory("mem", memory)
@@ -367,7 +367,7 @@ mod tests {
 
         // create an ImportModule instance
         let result = ImportObjectBuilder::<NeverType>::new()
-            .with_func::<(i32, i32), i32>("add", real_add, None)
+            .with_func::<(i32, i32), i32>("add", real_add)
             .expect("failed to add host function")
             .with_global("global", global_const)
             .with_memory("mem", memory)

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1298,7 +1298,7 @@ mod tests {
 
         // create an ImportModule instance
         let result = ImportObjectBuilder::<NeverType>::new()
-            .with_func::<(i32, i32), i32>("add", real_add, None)
+            .with_func::<(i32, i32), i32>("add", real_add)
             .expect("failed to add host function")
             .with_global("global", global_const)
             .with_memory("mem", memory)


### PR DESCRIPTION
In this PR, introduce `PluginModule` and `PluginModuleBuilder` into Rust SDK.