### PR TITLE
ci: Update `standalone` workflow

### DIFF
--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -40,7 +40,6 @@ jobs:
           export CXX=clang++
           export LD_LIBRARY_PATH=$HOME/.wasmedge/lib
           cargo test -p wasmedge-sdk --all --examples --features standalone
-          wasmedge --version
 
   build_ubuntu_2004:
     name: Ubuntu
@@ -75,7 +74,6 @@ jobs:
           export CXX=clang++
           export LD_LIBRARY_PATH=$HOME/.wasmedge/lib
           cargo test -p wasmedge-sdk --all --examples --features standalone
-          wasmedge --version
 
   build_fedora:
     name: Fedora
@@ -111,7 +109,6 @@ jobs:
           export CXX=clang++
           export LD_LIBRARY_PATH=$HOME/.wasmedge/lib
           cargo test -p wasmedge-sdk --all --examples --features standalone
-          wasmedge --version
 
   build_macos:
     name: MacOS
@@ -142,4 +139,3 @@ jobs:
           export CXX=clang++
           export DYLD_LIBRARY_PATH=$HOME/.wasmedge/lib
           cargo test -p wasmedge-sdk --all --examples --features standalone
-          wasmedge --version

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -75,39 +75,6 @@ jobs:
           export LD_LIBRARY_PATH=$HOME/.wasmedge/lib
           cargo test -p wasmedge-sdk --all --examples --features standalone
 
-  build_fedora:
-    name: Fedora
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust: [1.70.0, 1.69, 1.68]
-    container:
-      image: fedora:latest
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Set up build environment
-        run: |
-          dnf update -y
-          dnf install -y cmake ninja-build boost llvm llvm-devel lld-devel clang git file rpm-build dpkg-dev spdlog-devel
-          git config --global --add safe.directory $(pwd)
-
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ matrix.rust }}
-
-      - name: Run in the standalone mode
-        run: |
-          export LLVM_DIR="/usr/local/opt/llvm/lib/cmake"
-          export CC=clang
-          export CXX=clang++
-          export LD_LIBRARY_PATH=$HOME/.wasmedge/lib
-          cargo test -p wasmedge-sdk --all --examples --features standalone
-
   build_macos:
     name: MacOS
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -22,11 +22,11 @@ jobs:
 
       - name: Set up build environment
         run: |
-          sudo apt-get update
-          sudo apt-get install -y software-properties-common libboost-all-dev ninja-build
-          sudo apt-get install -y llvm-14-dev liblld-14-dev clang-14
-          sudo apt-get install -y gcc g++
-          sudo apt-get install -y libssl-dev pkg-config gh
+          sudo apt update
+          sudo apt install -y software-properties-common libboost-all-dev ninja-build
+          sudo apt install -y llvm-14-dev liblld-14-dev clang-14
+          sudo apt install -y gcc g++
+          sudo apt install -y libssl-dev pkg-config gh
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -56,11 +56,11 @@ jobs:
 
       - name: Set up build environment
         run: |
-          sudo apt-get update
-          sudo apt-get install -y software-properties-common libboost-all-dev ninja-build
-          sudo apt-get install -y llvm-12-dev liblld-12-dev clang-12
-          sudo apt-get install -y gcc g++
-          sudo apt-get install -y libssl-dev pkg-config gh
+          sudo apt update
+          sudo apt install -y software-properties-common libboost-all-dev ninja-build
+          sudo apt install -y llvm-12-dev liblld-12-dev clang-12
+          sudo apt install -y gcc g++
+          sudo apt install -y libssl-dev pkg-config gh
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -91,11 +91,9 @@ jobs:
 
       - name: Set up build environment
         run: |
-          sudo apt-get update
-          sudo apt-get install -y software-properties-common libboost-all-dev ninja-build
-          sudo apt-get install -y llvm-12-dev liblld-12-dev clang-12
-          sudo apt-get install -y gcc g++
-          sudo apt-get install -y libssl-dev pkg-config gh
+          dnf update -y
+          dnf install -y cmake ninja-build boost llvm llvm-devel lld-devel clang git file rpm-build dpkg-dev spdlog-devel
+          git config --global --add safe.directory $(pwd)
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,20 +4,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-on:
-  push:
-    paths:
-      - ".github/workflows/bindings-rust.yml"
-      - "src/**"
-      - "crates/**"
-
-  pull_request:
-    branches:
-      - main
-    paths:
-      - ".github/workflows/bindings-rust.yml"
-      - "src/**"
-      - "crates/**"
+on: [push, pull_request]
 
 jobs:
   build_ubuntu:
@@ -99,7 +86,7 @@ jobs:
         rust: [1.70.0, 1.69, 1.68]
     container:
       image: fedora:latest
-      
+
     steps:
       - uses: actions/checkout@v3
         with:

--- a/crates/wasmedge-sys/src/async_wasi.rs
+++ b/crates/wasmedge-sys/src/async_wasi.rs
@@ -25,7 +25,7 @@ impl async_wasi::snapshots::common::memory::Memory for Memory {
             let r = std::mem::size_of::<T>();
             let ptr = self
                 .data_pointer(offset.0 as u32, r as u32)
-                .map_err(|_| Errno::__WASI_ERRNO_FAULT)? as *const u8;
+                .map_err(|_| Errno::__WASI_ERRNO_FAULT)?;
             Ok(ptr.cast::<T>().as_ref().unwrap())
         }
     }
@@ -35,8 +35,7 @@ impl async_wasi::snapshots::common::memory::Memory for Memory {
             let r = std::mem::size_of::<T>() * len;
             let ptr = self
                 .data_pointer(offset.0 as u32, r as u32)
-                .map_err(|_| Errno::__WASI_ERRNO_FAULT)? as *const u8
-                as *const T;
+                .map_err(|_| Errno::__WASI_ERRNO_FAULT)? as *const T;
             Ok(std::slice::from_raw_parts(ptr, len))
         }
     }
@@ -52,7 +51,7 @@ impl async_wasi::snapshots::common::memory::Memory for Memory {
             for i in iovec {
                 let ptr = self
                     .data_pointer(i.buf, i.buf_len)
-                    .map_err(|_| Errno::__WASI_ERRNO_FAULT)? as *const u8;
+                    .map_err(|_| Errno::__WASI_ERRNO_FAULT)?;
                 let s = std::io::IoSlice::new(std::slice::from_raw_parts(ptr, i.buf_len as usize));
                 result.push(s);
             }
@@ -65,7 +64,7 @@ impl async_wasi::snapshots::common::memory::Memory for Memory {
             let r = std::mem::size_of::<T>();
             let ptr = self
                 .data_pointer_mut(offset.0 as u32, r as u32)
-                .map_err(|_| Errno::__WASI_ERRNO_FAULT)? as *mut u8;
+                .map_err(|_| Errno::__WASI_ERRNO_FAULT)?;
             Ok(ptr.cast::<T>().as_mut().unwrap())
         }
     }
@@ -75,7 +74,7 @@ impl async_wasi::snapshots::common::memory::Memory for Memory {
             let r = std::mem::size_of::<T>() * len;
             let ptr = self
                 .data_pointer_mut(offset.0 as u32, r as u32)
-                .map_err(|_| Errno::__WASI_ERRNO_FAULT)? as *mut u8 as *mut T;
+                .map_err(|_| Errno::__WASI_ERRNO_FAULT)? as *mut T;
             Ok(std::slice::from_raw_parts_mut(ptr, len))
         }
     }
@@ -91,7 +90,7 @@ impl async_wasi::snapshots::common::memory::Memory for Memory {
             for i in iovec {
                 let ptr = self
                     .data_pointer_mut(i.buf, i.buf_len)
-                    .map_err(|_| Errno::__WASI_ERRNO_FAULT)? as *mut u8;
+                    .map_err(|_| Errno::__WASI_ERRNO_FAULT)?;
                 let s = std::io::IoSliceMut::new(std::slice::from_raw_parts_mut(
                     ptr,
                     i.buf_len as usize,

--- a/crates/wasmedge-sys/src/compiler.rs
+++ b/crates/wasmedge-sys/src/compiler.rs
@@ -124,7 +124,7 @@ impl Compiler {
                 out_path.as_ptr(),
             ))?;
 
-            libc::free(ptr as *mut libc::c_void);
+            libc::free(ptr);
         }
 
         Ok(())

--- a/crates/wasmedge-sys/src/loader.rs
+++ b/crates/wasmedge-sys/src/loader.rs
@@ -142,7 +142,7 @@ impl Loader {
                 bytes.as_ref().len() as u32,
             ))?;
 
-            libc::free(ptr as *mut libc::c_void);
+            libc::free(ptr);
         }
 
         match mod_ctx.is_null() {


### PR DESCRIPTION
In this PR, the `standalone` workflow is updated by removing the `build_fedora` job. In addition, fix some `clippy` issues which are detected by the udpated `clippy`. 