### PR TITLE
[refactor] Improve `Function` and `ImportModule`

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04]
-        rust: [1.70.0, 1.69, 1.68]
+        rust: [1.71, 1.70.0, 1.69]
     container:
       image: wasmedge/wasmedge:ubuntu-build-clang
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,9 @@ thiserror = "1.0.30"
 wasmedge-macro = {path = "crates/wasmedge-macro", version = "0.5"}
 wasmedge-sys = {path = "crates/wasmedge-sys", version = "0.15", default-features = false}
 wasmedge-types = {path = "crates/wasmedge-types", version = "0.4"}
-wat = "1.0"
+
+[workspace.dependencies]
+wat = "^1.0.67"
 
 [features]
 aot = ["wasmedge-sys/aot"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ wasmedge-sys = {path = "crates/wasmedge-sys", version = "0.15", default-features
 wasmedge-types = {path = "crates/wasmedge-types", version = "0.4"}
 
 [workspace.dependencies]
-wat = "^1.0.67"
+wat = "=1.0.67"
 
 [features]
 aot = ["wasmedge-sys/aot"]

--- a/crates/wasmedge-sys/Cargo.toml
+++ b/crates/wasmedge-sys/Cargo.toml
@@ -20,7 +20,7 @@ scoped-tls = "1"
 thiserror = "1.0.30"
 wasmedge-macro = {path = "../wasmedge-macro", version = "0.5"}
 wasmedge-types = {path = "../wasmedge-types", version = "0.4"}
-wat = "1.0"
+wat.workspace = true
 lazy_static = "1.4.0"
 parking_lot = "0.12.1"
 rand = "0.8.4"

--- a/crates/wasmedge-sys/examples/async_host_func.rs
+++ b/crates/wasmedge-sys/examples/async_host_func.rs
@@ -7,37 +7,62 @@
 //! ```
 
 #[cfg(feature = "async")]
-use wasmedge_sys::{r#async::AsyncState, Executor, FuncType, Function};
+use wasmedge_sys::{r#async::AsyncState, CallingFrame, Executor, FuncType, Function, WasmValue};
+#[cfg(feature = "async")]
+use wasmedge_types::error::HostFuncError;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(feature = "async")]
     {
+        #[derive(Debug)]
+        struct Data<T, S> {
+            _x: i32,
+            _y: String,
+            _v: Vec<T>,
+            _s: Vec<S>,
+        }
+        let data: Data<i32, &str> = Data {
+            _x: 12,
+            _y: "hello".to_string(),
+            _v: vec![1, 2, 3],
+            _s: vec!["macos", "linux", "windows"],
+        };
+
         // create a FuncType
         let func_ty = FuncType::create(vec![], vec![])?;
 
-        // create a host function
-        let async_host_func = Function::create_async_func(
-            &func_ty,
-            Box::new(|_frame, _input, _data| {
-                Box::new(async {
-                    println!("Hello, world!");
+        // define an async closure
+        let c = |_frame: CallingFrame,
+                 _args: Vec<WasmValue>,
+                 data: *mut std::os::raw::c_void|
+         -> Box<
+            (dyn std::future::Future<Output = Result<Vec<WasmValue>, HostFuncError>> + Send),
+        > {
+            let data = unsafe { Box::from_raw(data as *mut Data<i32, &str>) };
+
+            Box::new(async move {
+                println!("Hello, world!");
+                println!("host_data: {:?}", data);
+
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                // Wrap the future with a `Timeout` set to expire in 10 milliseconds.
+                let res = tokio::time::timeout(std::time::Duration::from_millis(100), async {
                     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-                    // Wrap the future with a `Timeout` set to expire in 10 milliseconds.
-                    let res = tokio::time::timeout(std::time::Duration::from_millis(100), async {
-                        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-                    })
-                    .await;
-                    if res.is_err() {
-                        println!("did not receive value within 100 ms");
-                    }
-                    println!("Rust: Leaving Rust function real_add");
-                    println!("Hello, world after sleep!");
-                    Ok(vec![])
                 })
-            }),
-            0,
-        )?;
+                .await;
+                if res.is_err() {
+                    println!("did not receive value within 100 ms");
+                }
+                println!("Rust: Leaving Rust function real_add");
+                println!("Hello, world after sleep!");
+                Ok(vec![])
+            })
+        };
+
+        // create a host function
+        let async_host_func =
+            Function::create_async_func(&func_ty, Box::new(c), Some(Box::new(data)), 0)?;
 
         // run this function
         let mut executor = Executor::create(None, None)?;

--- a/crates/wasmedge-sys/examples/context_data_to_host_func.rs
+++ b/crates/wasmedge-sys/examples/context_data_to_host_func.rs
@@ -1,4 +1,3 @@
-use wasmedge_macro::sys_host_function;
 use wasmedge_sys::{CallingFrame, Executor, FuncType, Function, WasmValue};
 use wasmedge_types::{error::HostFuncError, ValType};
 
@@ -10,15 +9,15 @@ struct Data<T, S> {
     _s: Vec<S>,
 }
 
-#[sys_host_function]
-fn real_add(
+fn real_add<T: core::fmt::Debug>(
     _frame: CallingFrame,
     input: Vec<WasmValue>,
-    data: &mut Data<i32, &str>,
+    data: *mut std::ffi::c_void,
 ) -> Result<Vec<WasmValue>, HostFuncError> {
     println!("Rust: Entering Rust function real_add");
 
-    println!("data: {data:?}");
+    let host_data = unsafe { Box::from_raw(data as *mut T) };
+    println!("host_data: {:?}", host_data);
 
     if input.len() != 2 {
         return Err(HostFuncError::User(1));
@@ -44,7 +43,7 @@ fn real_add(
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut data: Data<i32, &str> = Data {
+    let data: Data<i32, &str> = Data {
         _x: 12,
         _y: "hello".to_string(),
         _v: vec![1, 2, 3],
@@ -56,7 +55,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert!(result.is_ok());
     let func_ty = result.unwrap();
     // create a host function
-    let result = Function::create_sync_func(&func_ty, Box::new(real_add), Some(&mut data), 0);
+    let result = Function::create_sync_func(
+        &func_ty,
+        Box::new(real_add::<Data<i32, &str>>),
+        Some(Box::new(data)),
+        0,
+    );
     assert!(result.is_ok());
     let host_func = result.unwrap();
 

--- a/crates/wasmedge-sys/examples/func_call_across_different_modes.rs
+++ b/crates/wasmedge-sys/examples/func_call_across_different_modes.rs
@@ -45,7 +45,7 @@ fn interpreter_call_aot() -> Result<(), Box<dyn std::error::Error>> {
     let mut store = Store::create()?;
 
     // create an import module
-    let mut import = ImportModule::<NeverType>::create("host", None)?;
+    let mut import = ImportModule::create::<NeverType>("host", None)?;
 
     // import host_print_i32 as a host function
     let func_ty = FuncType::create([ValType::I32], [])?;
@@ -132,7 +132,7 @@ fn aot_call_interpreter() -> Result<(), Box<dyn std::error::Error>> {
     let mut store = Store::create()?;
 
     // create an import module
-    let mut import = ImportModule::<NeverType>::create("host", None)?;
+    let mut import = ImportModule::create::<NeverType>("host", None)?;
 
     // import host_print_i32 as a host function
     let func_ty = FuncType::create([ValType::I32], [])?;

--- a/crates/wasmedge-sys/examples/hostfunc.rs
+++ b/crates/wasmedge-sys/examples/hostfunc.rs
@@ -60,7 +60,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let host_func = Function::create_sync_func::<NeverType>(&func_ty, Box::new(real_add), None, 0)?;
 
     // create an ImportObject module
-    let mut import = ImportModule::<NeverType>::create("extern_module", None)?;
+    let mut import = ImportModule::create::<NeverType>("extern_module", None)?;
     import.add_func("add", host_func);
 
     // create a config

--- a/crates/wasmedge-sys/examples/hostfunc2.rs
+++ b/crates/wasmedge-sys/examples/hostfunc2.rs
@@ -48,7 +48,7 @@ fn real_add(_frame: CallingFrame, input: Vec<WasmValue>) -> Result<Vec<WasmValue
 #[cfg_attr(test, test)]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config = Config::create()?;
-    let mut import = ImportModule::<NeverType>::create("extern_module", None)?;
+    let mut import = ImportModule::create::<NeverType>("extern_module", None)?;
 
     let result = FuncType::create(
         vec![ValType::ExternRef, ValType::I32, ValType::I32],

--- a/crates/wasmedge-sys/examples/table_and_funcref.rs
+++ b/crates/wasmedge-sys/examples/table_and_funcref.rs
@@ -53,7 +53,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     table.set_data(WasmValue::from_func_ref(host_func.as_ref()), 3)?;
 
     // add the table instance to the import object
-    let mut import = ImportModule::<NeverType>::create("extern", None)?;
+    let mut import = ImportModule::create::<NeverType>("extern", None)?;
     import.add_table("my-table", table);
 
     // create a config

--- a/crates/wasmedge-sys/src/executor.rs
+++ b/crates/wasmedge-sys/src/executor.rs
@@ -680,7 +680,8 @@ mod tests {
         assert!(result.is_ok());
 
         let ty = FuncType::create([], [])?;
-        let async_hello_func = Function::create_async_func(&ty, Box::new(async_hello), 0)?;
+        let async_hello_func =
+            Function::create_async_func::<NeverType>(&ty, Box::new(async_hello), None, 0)?;
         let mut import = ImportModule::<NeverType>::create("extern", None)?;
         import.add_func("async_hello", async_hello_func);
 

--- a/crates/wasmedge-sys/src/executor.rs
+++ b/crates/wasmedge-sys/src/executor.rs
@@ -67,10 +67,10 @@ impl Executor {
     /// # Error
     ///
     /// If fail to register the given [import object](crate::ImportObject), then an error is returned.
-    pub fn register_import_object<T: Send + Sync + Clone>(
+    pub fn register_import_object(
         &mut self,
         store: &Store,
-        import: &ImportObject<T>,
+        import: &ImportObject,
     ) -> WasmEdgeResult<()> {
         match import {
             ImportObject::Import(import) => unsafe {
@@ -446,7 +446,7 @@ mod tests {
 
         // create an ImportObj module
         let host_name = "extern";
-        let result = ImportModule::<NeverType>::create(host_name, None);
+        let result = ImportModule::create::<NeverType>(host_name, None);
         assert!(result.is_ok());
         let mut import = result.unwrap();
 
@@ -601,7 +601,7 @@ mod tests {
         let async_wasi_module = result.unwrap();
 
         // register async_wasi module into the store
-        let wasi_import = ImportObject::<NeverType>::AsyncWasi(async_wasi_module);
+        let wasi_import = ImportObject::AsyncWasi(async_wasi_module);
         let result = executor.register_import_object(&mut store, &wasi_import);
         assert!(result.is_ok());
 
@@ -675,14 +675,14 @@ mod tests {
         let async_wasi_module = result.unwrap();
 
         // register async_wasi module into the store
-        let wasi_import = ImportObject::<NeverType>::AsyncWasi(async_wasi_module);
+        let wasi_import = ImportObject::AsyncWasi(async_wasi_module);
         let result = executor.register_import_object(&mut store, &wasi_import);
         assert!(result.is_ok());
 
         let ty = FuncType::create([], [])?;
         let async_hello_func =
             Function::create_async_func::<NeverType>(&ty, Box::new(async_hello), None, 0)?;
-        let mut import = ImportModule::<NeverType>::create("extern", None)?;
+        let mut import = ImportModule::create::<NeverType>("extern", None)?;
         import.add_func("async_hello", async_hello_func);
 
         let extern_import = ImportObject::Import(import);

--- a/crates/wasmedge-sys/src/instance/function.rs
+++ b/crates/wasmedge-sys/src/instance/function.rs
@@ -1327,7 +1327,7 @@ mod tests {
             let mut store = result.unwrap();
 
             // create an ImportModule
-            let mut import = ImportModule::<NeverType>::create("extern", None)?;
+            let mut import = ImportModule::create::<NeverType>("extern", None)?;
             import.add_func("add", host_func);
             let extern_import = ImportObject::Import(import);
 
@@ -1411,7 +1411,7 @@ mod tests {
         assert_eq!(HOST_FUNC_FOOTPRINTS.lock().len(), 1);
 
         // create an ImportModule
-        let mut import_module = ImportModule::<NeverType>::create("extern", None)?;
+        let mut import_module = ImportModule::create::<NeverType>("extern", None)?;
         // add the host function to the import module
         import_module.add_func("add", host_func);
 
@@ -1579,12 +1579,12 @@ mod tests {
             let async_wasi_module = result.unwrap();
 
             // register async_wasi module into the store
-            let wasi_import = ImportObject::<NeverType>::AsyncWasi(async_wasi_module);
+            let wasi_import = ImportObject::AsyncWasi(async_wasi_module);
             let result = executor.register_import_object(&mut store, &wasi_import);
             assert!(result.is_ok());
 
             // create an ImportModule
-            let mut import = ImportModule::<NeverType>::create("extern", None)?;
+            let mut import = ImportModule::create::<NeverType>("extern", None)?;
             import.add_func("async_hello", async_hello_func);
 
             let extern_import = ImportObject::Import(import);
@@ -1687,12 +1687,12 @@ mod tests {
             let async_wasi_module = result.unwrap();
 
             // register async_wasi module into the store
-            let wasi_import = ImportObject::<NeverType>::AsyncWasi(async_wasi_module);
+            let wasi_import = ImportObject::AsyncWasi(async_wasi_module);
             let result = executor.register_import_object(&mut store, &wasi_import);
             assert!(result.is_ok());
 
             // create an ImportModule
-            let mut import = ImportModule::<NeverType>::create("extern", None)?;
+            let mut import = ImportModule::create::<NeverType>("extern", None)?;
             import.add_func("async_hello", async_hello_func);
 
             let extern_import = ImportObject::Import(import);

--- a/crates/wasmedge-sys/src/plugin.rs
+++ b/crates/wasmedge-sys/src/plugin.rs
@@ -2,7 +2,10 @@
 
 use super::ffi;
 use crate::{
-    instance::{module::InnerInstance, Function, Global, Memory, Table},
+    instance::{
+        module::{host_data_finalizer, InnerInstance},
+        Function, Global, Memory, Table,
+    },
     types::WasmEdgeString,
     utils, AsImport, Instance, WasmEdgeResult,
 };
@@ -582,11 +585,6 @@ impl<T: Send + Sync + Clone> AsImport for PluginModule<T> {
         }
         global.inner.lock().0 = std::ptr::null_mut();
     }
-}
-
-unsafe extern "C" fn host_data_finalizer<T: Sized + Send>(raw: *mut ::std::os::raw::c_void) {
-    let host_data: Box<T> = Box::from_raw(raw as *mut T);
-    drop(host_data);
 }
 
 #[cfg(test)]

--- a/crates/wasmedge-sys/src/store.rs
+++ b/crates/wasmedge-sys/src/store.rs
@@ -154,7 +154,7 @@ mod tests {
         assert!(store.module_names().is_none());
 
         // create ImportObject instance
-        let result = ImportModule::<NeverType>::create(module_name, None);
+        let result = ImportModule::create::<NeverType>(module_name, None);
         assert!(result.is_ok());
         let mut import = result.unwrap();
 
@@ -240,7 +240,7 @@ mod tests {
         let store_cloned = Arc::clone(&store);
         let handle = thread::spawn(move || {
             // create ImportObject instance
-            let result = ImportModule::<NeverType>::create("extern_module", None);
+            let result = ImportModule::create::<NeverType>("extern_module", None);
             assert!(result.is_ok());
             let mut import = result.unwrap();
 

--- a/crates/wasmedge-sys/tests/common.rs
+++ b/crates/wasmedge-sys/tests/common.rs
@@ -2,9 +2,9 @@ use wasmedge_macro::sys_host_function;
 use wasmedge_sys::{AsImport, CallingFrame, FuncType, Function, ImportModule, WasmValue};
 use wasmedge_types::{error::HostFuncError, NeverType, ValType};
 
-pub fn create_extern_module(name: impl AsRef<str>) -> ImportModule<NeverType> {
+pub fn create_extern_module(name: impl AsRef<str>) -> ImportModule {
     // create an import module
-    let result = ImportModule::<NeverType>::create(name, None);
+    let result = ImportModule::create::<NeverType>(name, None);
     assert!(result.is_ok());
     let mut import = result.unwrap();
 

--- a/crates/wasmedge-sys/tests/test_aot.rs
+++ b/crates/wasmedge-sys/tests/test_aot.rs
@@ -86,9 +86,9 @@ fn test_aot() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[cfg(feature = "aot")]
-fn create_spec_test_module() -> ImportModule<NeverType> {
+fn create_spec_test_module() -> ImportModule {
     // create an ImportObj module
-    let result = ImportModule::<NeverType>::create("spectest", None);
+    let result = ImportModule::create::<NeverType>("spectest", None);
     assert!(result.is_ok());
     let mut import = result.unwrap();
 

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -97,7 +97,7 @@ mod tests {
     use super::*;
     use crate::{
         config::{CompilerConfigOptions, ConfigBuilder},
-        params, wat2wasm, CompilerOutputFormat, NeverType, VmBuilder, WasmVal,
+        params, wat2wasm, CompilerOutputFormat, VmBuilder, WasmVal,
     };
     use std::io::Read;
 
@@ -133,11 +133,10 @@ mod tests {
             let wasm_magic: [u8; 4] = [0x00, 0x61, 0x73, 0x6D];
             assert_ne!(buffer, wasm_magic);
 
-            let res = VmBuilder::new().build::<NeverType>()?.run_func_from_file(
-                &aot_file_path,
-                "fib",
-                params!(5),
-            )?;
+            let res =
+                VmBuilder::new()
+                    .build()?
+                    .run_func_from_file(&aot_file_path, "fib", params!(5))?;
             assert_eq!(res[0].to_i32(), 8);
 
             // cleanup
@@ -207,11 +206,10 @@ mod tests {
             let wasm_magic: [u8; 4] = [0x00, 0x61, 0x73, 0x6D];
             assert_ne!(buffer, wasm_magic);
 
-            let res = VmBuilder::new().build::<NeverType>()?.run_func_from_file(
-                &aot_file_path,
-                "fib",
-                params!(5),
-            )?;
+            let res =
+                VmBuilder::new()
+                    .build()?
+                    .run_func_from_file(&aot_file_path, "fib", params!(5))?;
             assert_eq!(res[0].to_i32(), 8);
 
             // cleanup

--- a/src/dock.rs
+++ b/src/dock.rs
@@ -7,17 +7,17 @@ use std::any::Any;
 
 /// Extends a [Vm](crate::Vm) instance by supporting function arguments of Rust built-in types.
 #[derive(Debug)]
-pub struct VmDock<T: Send + Sync + Clone> {
-    pub(crate) vm: Box<Vm<T>>, // Can't use Arc because vm can be get_mut after cloned for hostfunc
+pub struct VmDock {
+    pub(crate) vm: Box<Vm>, // Can't use Arc because vm can be get_mut after cloned for hostfunc
 }
-impl<T: Send + Sync + Clone> VmDock<T> {
+impl VmDock {
     /// Creates a new [VmDock] to be associated with the given [Vm](crate::Vm).
     ///
     /// # Arguments
     ///
     /// * `vm` - The [Vm] instance to be extended.
     ///
-    pub fn new(vm: Vm<T>) -> Self {
+    pub fn new(vm: Vm) -> Self {
         VmDock { vm: Box::new(vm) }
     }
 
@@ -251,8 +251,8 @@ impl<T: Send + Sync + Clone> VmDock<T> {
         self.vm.run_func(mod_name, "deallocate", args)
     }
 }
-unsafe impl<T: Send + Sync + Clone> Send for VmDock<T> {}
-unsafe impl<T: Send + Sync + Clone> Sync for VmDock<T> {}
+unsafe impl Send for VmDock {}
+unsafe impl Sync for VmDock {}
 
 /// Defines a type container that wraps a value of Rust built-in type.
 #[derive(Debug)]
@@ -279,11 +279,7 @@ pub enum Param<'a> {
     String(&'a str),
 }
 impl<'a> Param<'a> {
-    fn settle<T: Send + Sync + Clone>(
-        &self,
-        vm: &VmDock<T>,
-        mem: &mut Memory,
-    ) -> WasmEdgeResult<(i32, i32)> {
+    fn settle(&self, vm: &VmDock, mem: &mut Memory) -> WasmEdgeResult<(i32, i32)> {
         match self {
             Param::I8(v) => {
                 let length = 1;
@@ -471,7 +467,7 @@ impl<'a> Param<'a> {
         }
     }
 
-    fn allocate<T: Send + Sync + Clone>(dock: &VmDock<T>, size: i32) -> WasmEdgeResult<i32> {
+    fn allocate(dock: &VmDock, size: i32) -> WasmEdgeResult<i32> {
         let res = dock.vm.run_func(None, "allocate", params!(size))?;
 
         Ok(res[0].to_i32())

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -281,8 +281,23 @@ mod tests {
             })
         }
 
+        #[derive(Debug)]
+        struct Data<T, S> {
+            _x: i32,
+            _y: String,
+            _v: Vec<T>,
+            _s: Vec<S>,
+        }
+        let data: Data<i32, &str> = Data {
+            _x: 12,
+            _y: "hello".to_string(),
+            _v: vec![1, 2, 3],
+            _s: vec!["macos", "linux", "windows"],
+        };
+
         // create an async host function
-        let result = Func::wrap_async_func::<(), ()>(async_hello);
+        let result =
+            Func::wrap_async_func::<(), (), Data<i32, &str>>(async_hello, Some(Box::new(data)));
         assert!(result.is_ok());
         let func = result.unwrap();
 

--- a/src/externals/function.rs
+++ b/src/externals/function.rs
@@ -44,7 +44,7 @@ impl Func {
             + Send
             + Sync
             + 'static,
-        data: Option<&mut T>,
+        data: Option<Box<T>>,
     ) -> WasmEdgeResult<Self> {
         let boxed_func = Box::new(real_func);
         let inner = sys::Function::create_sync_func::<T>(&ty.clone().into(), boxed_func, data, 0)?;
@@ -76,7 +76,7 @@ impl Func {
             + Send
             + Sync
             + 'static,
-        data: Option<&mut T>,
+        data: Option<Box<T>>,
     ) -> WasmEdgeResult<Self>
     where
         Args: WasmValTypeList,
@@ -107,7 +107,7 @@ impl Func {
     ///
     /// * If fail to create a Func instance, then [WasmEdgeError::Func(FuncError::Create)](crate::error::FuncError) is returned.
     #[cfg(all(feature = "async", target_os = "linux"))]
-    pub fn wrap_async_func<Args, Rets>(
+    pub fn wrap_async_func<Args, Rets, T>(
         real_func: impl Fn(
                 CallingFrame,
                 Vec<WasmValue>,
@@ -119,16 +119,18 @@ impl Func {
             > + Send
             + Sync
             + 'static,
+        data: Option<Box<T>>,
     ) -> WasmEdgeResult<Self>
     where
         Args: WasmValTypeList,
         Rets: WasmValTypeList,
+        T: Send + Sync,
     {
         let boxed_func = Box::new(real_func);
         let args = Args::wasm_types();
         let returns = Rets::wasm_types();
         let ty = FuncType::new(Some(args.to_vec()), Some(returns.to_vec()));
-        let inner = sys::Function::create_async_func(&ty.clone().into(), boxed_func, 0)?;
+        let inner = sys::Function::create_async_func(&ty.clone().into(), boxed_func, data, 0)?;
         Ok(Self {
             inner,
             name: None,
@@ -554,14 +556,17 @@ mod tests {
         // define an async closure
         let c = |_frame: CallingFrame,
                  _args: Vec<WasmValue>,
-                 _data: *mut std::os::raw::c_void|
+                 data: *mut std::os::raw::c_void|
          -> Box<
             (dyn std::future::Future<Output = Result<Vec<WasmValue>, HostFuncError>> + Send),
         > {
+            let data = unsafe { Box::from_raw(data as *mut Data<i32, &str>) };
+
             Box::new(async move {
                 for _ in 0..10 {
                     println!("[async hello] say hello");
                     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                    println!("host_data: {:?}", data);
                 }
 
                 println!("[async hello] Done!");
@@ -570,9 +575,23 @@ mod tests {
             })
         };
 
+        #[derive(Debug)]
+        struct Data<T, S> {
+            _x: i32,
+            _y: String,
+            _v: Vec<T>,
+            _s: Vec<S>,
+        }
+        let data: Data<i32, &str> = Data {
+            _x: 12,
+            _y: "hello".to_string(),
+            _v: vec![1, 2, 3],
+            _s: vec!["macos", "linux", "windows"],
+        };
+
         // create an ImportModule instance
         let result = ImportObjectBuilder::<NeverType>::new()
-            .with_async_func::<(), ()>("async_hello", c)?
+            .with_async_func::<(), (), Data<i32, &str>>("async_hello", c, Some(Box::new(data)))?
             .build("extern");
         assert!(result.is_ok());
         let import = result.unwrap();

--- a/src/externals/function.rs
+++ b/src/externals/function.rs
@@ -398,10 +398,10 @@ mod tests {
     #[allow(clippy::assertions_on_result_states)]
     fn test_func_basic() {
         // create an ImportModule
-        let result = ImportObjectBuilder::<NeverType>::new()
+        let result = ImportObjectBuilder::new()
             .with_func::<(i32, i32), i32, NeverType>("add", real_add, None)
             .expect("failed to add host func")
-            .build("extern");
+            .build::<NeverType>("extern", None);
         assert!(result.is_ok());
         let import = result.unwrap();
 
@@ -527,15 +527,15 @@ mod tests {
         };
 
         // create an ImportModule instance
-        let result = ImportObjectBuilder::<NeverType>::new()
+        let result = ImportObjectBuilder::new()
             // .with_sync_closure::<(i32, i32), i32>("add", real_add)?
             .with_func::<(i32, i32), i32, NeverType>("add", real_add, None)?
-            .build("extern");
+            .build::<NeverType>("extern", None);
         assert!(result.is_ok());
         let import = result.unwrap();
 
         // create a Vm context
-        let result = VmBuilder::new().build::<NeverType>();
+        let result = VmBuilder::new().build();
         assert!(result.is_ok());
         let vm = result.unwrap();
 
@@ -590,14 +590,14 @@ mod tests {
         };
 
         // create an ImportModule instance
-        let result = ImportObjectBuilder::<NeverType>::new()
+        let result = ImportObjectBuilder::new()
             .with_async_func::<(), (), Data<i32, &str>>("async_hello", c, Some(Box::new(data)))?
-            .build("extern");
+            .build::<NeverType>("extern", None);
         assert!(result.is_ok());
         let import = result.unwrap();
 
         // create a Vm context
-        let result = VmBuilder::new().build::<NeverType>();
+        let result = VmBuilder::new().build();
         assert!(result.is_ok());
         let vm = result.unwrap();
 

--- a/src/externals/global.rs
+++ b/src/externals/global.rs
@@ -120,10 +120,10 @@ mod tests {
         let global_var = result.unwrap();
 
         // create an import object
-        let result = ImportObjectBuilder::<NeverType>::new()
+        let result = ImportObjectBuilder::new()
             .with_global("const-global", global_const)
             .with_global("var-global", global_var)
-            .build("extern");
+            .build::<NeverType>("extern", None);
         assert!(result.is_ok());
         let import = result.unwrap();
 

--- a/src/externals/memory.rs
+++ b/src/externals/memory.rs
@@ -200,9 +200,9 @@ mod tests {
         let memory = result.unwrap();
 
         // create an import object
-        let result = ImportObjectBuilder::<NeverType>::new()
+        let result = ImportObjectBuilder::new()
             .with_memory("memory", memory)
-            .build("extern");
+            .build::<NeverType>("extern", None);
         assert!(result.is_ok());
         let import = result.unwrap();
 

--- a/src/externals/table.rs
+++ b/src/externals/table.rs
@@ -150,11 +150,11 @@ mod tests {
         let table = result.unwrap();
 
         // create an import object
-        let result = ImportObjectBuilder::<NeverType>::new()
+        let result = ImportObjectBuilder::new()
             .with_func::<(i32, i32), i32, NeverType>("add", real_add, None)
             .expect("failed to add host func")
             .with_table("table", table)
-            .build("extern");
+            .build::<NeverType>("extern", None);
         assert!(result.is_ok());
         let import = result.unwrap();
 

--- a/src/import.rs
+++ b/src/import.rs
@@ -56,7 +56,7 @@ impl<T: Send + Sync + Clone> ImportObjectBuilder<T> {
             + Send
             + Sync
             + 'static,
-        data: Option<&mut D>,
+        data: Option<Box<D>>,
     ) -> WasmEdgeResult<Self>
     where
         Args: WasmValTypeList,
@@ -100,7 +100,7 @@ impl<T: Send + Sync + Clone> ImportObjectBuilder<T> {
             + Send
             + Sync
             + 'static,
-        data: Option<&mut D>,
+        data: Option<Box<D>>,
     ) -> WasmEdgeResult<Self> {
         let boxed_func = Box::new(real_func);
         let inner_func = sys::Function::create_sync_func::<D>(&ty.into(), boxed_func, data, 0)?;
@@ -122,7 +122,7 @@ impl<T: Send + Sync + Clone> ImportObjectBuilder<T> {
     ///
     /// If fail to create or add the [host function](crate::Func), then an error is returned.
     #[cfg(all(feature = "async", target_os = "linux"))]
-    pub fn with_async_func<Args, Rets>(
+    pub fn with_async_func<Args, Rets, D>(
         mut self,
         name: impl AsRef<str>,
         real_func: impl Fn(
@@ -134,15 +134,18 @@ impl<T: Send + Sync + Clone> ImportObjectBuilder<T> {
             > + Send
             + Sync
             + 'static,
+        data: Option<Box<D>>,
     ) -> WasmEdgeResult<Self>
     where
         Args: WasmValTypeList,
         Rets: WasmValTypeList,
+        D: Send + Sync,
     {
         let args = Args::wasm_types();
         let returns = Rets::wasm_types();
         let ty = FuncType::new(Some(args.to_vec()), Some(returns.to_vec()));
-        let inner_func = sys::Function::create_async_func(&ty.into(), Box::new(real_func), 0)?;
+        let inner_func =
+            sys::Function::create_async_func(&ty.into(), Box::new(real_func), data, 0)?;
         self.funcs.push((name.as_ref().to_owned(), inner_func));
         Ok(self)
     }

--- a/src/import.rs
+++ b/src/import.rs
@@ -11,14 +11,13 @@ use wasmedge_sys::{self as sys, AsImport, WasmValue};
 /// This example shows how to create a normal import object that contains a host function, a global variable, a memory and a table. The import object is named "extern".
 ///
 #[derive(Debug, Default)]
-pub struct ImportObjectBuilder<T: Send + Sync + Clone> {
+pub struct ImportObjectBuilder {
     funcs: Vec<(String, sys::Function)>,
     globals: Vec<(String, sys::Global)>,
     memories: Vec<(String, sys::Memory)>,
     tables: Vec<(String, sys::Table)>,
-    host_data: Option<Box<T>>,
 }
-impl<T: Send + Sync + Clone> ImportObjectBuilder<T> {
+impl ImportObjectBuilder {
     /// Creates a new [ImportObjectBuilder].
     pub fn new() -> Self {
         Self {
@@ -26,7 +25,6 @@ impl<T: Send + Sync + Clone> ImportObjectBuilder<T> {
             globals: Vec::new(),
             memories: Vec::new(),
             tables: Vec::new(),
-            host_data: None,
         }
     }
 
@@ -189,28 +187,23 @@ impl<T: Send + Sync + Clone> ImportObjectBuilder<T> {
         self
     }
 
-    /// Adds host data to the [ImportObject] to create.
-    ///
-    /// # Arguments
-    ///
-    /// * `host_data` - The host data to be stored in the module instance.
-    ///
-    pub fn with_host_data(mut self, host_data: Box<T>) -> Self {
-        self.host_data = Some(host_data);
-        self
-    }
-
     /// Creates a new [ImportObject].
     ///
     /// # Argument
     ///
     /// * `name` - The name of the [ImportObject] to create.
     ///
+    /// * `host_data` - The host data to be stored in the module instance.
+    ///
     /// # Error
     ///
     /// If fail to create the [ImportObject], then an error is returned.
-    pub fn build(self, name: impl AsRef<str>) -> WasmEdgeResult<ImportObject<T>> {
-        let mut inner = sys::ImportModule::create(name.as_ref(), self.host_data)?;
+    pub fn build<T: Send + Sync>(
+        self,
+        name: impl AsRef<str>,
+        host_data: Option<Box<T>>,
+    ) -> WasmEdgeResult<ImportObject> {
+        let mut inner = sys::ImportModule::create(name.as_ref(), host_data)?;
 
         // add func
         for (name, func) in self.funcs.into_iter() {
@@ -240,8 +233,8 @@ impl<T: Send + Sync + Clone> ImportObjectBuilder<T> {
 ///
 /// An [ImportObject] instance is created with [ImportObjectBuilder](crate::ImportObjectBuilder).
 #[derive(Debug, Clone)]
-pub struct ImportObject<T: Send + Sync + Clone>(pub(crate) sys::ImportObject<T>);
-impl<T: Send + Sync + Clone> ImportObject<T> {
+pub struct ImportObject(pub(crate) sys::ImportObject);
+impl ImportObject {
     /// Returns the name of the import object.
     pub fn name(&self) -> &str {
         match &self.0 {
@@ -253,7 +246,7 @@ impl<T: Send + Sync + Clone> ImportObject<T> {
         }
     }
 
-    pub(crate) fn inner_ref(&self) -> &sys::ImportObject<T> {
+    pub(crate) fn inner_ref(&self) -> &sys::ImportObject {
         &self.0
     }
 
@@ -283,7 +276,7 @@ mod tests {
     #[test]
     #[allow(clippy::assertions_on_result_states)]
     fn test_import_builder() {
-        let result = ImportObjectBuilder::<NeverType>::new().build("extern");
+        let result = ImportObjectBuilder::new().build::<NeverType>("extern", None);
         assert!(result.is_ok());
         let import = result.unwrap();
         assert_eq!(import.name(), "extern");
@@ -298,11 +291,9 @@ mod tests {
             radius: i32,
         }
 
-        let circle = Box::new(Circle { radius: 10 });
+        let circle = Circle { radius: 10 };
 
-        let result = ImportObjectBuilder::<Circle>::new()
-            .with_host_data(circle)
-            .build("extern");
+        let result = ImportObjectBuilder::new().build("extern", Some(Box::new(circle)));
         assert!(result.is_ok());
 
         let import = result.unwrap();
@@ -359,10 +350,10 @@ mod tests {
         }
 
         // create an import object
-        let result = ImportObjectBuilder::<NeverType>::new()
+        let result = ImportObjectBuilder::new()
             .with_func::<(i32, i32), i32, NeverType>("add", real_add, None)
             .expect("failed to add host func")
-            .build("extern");
+            .build::<NeverType>("extern", None);
         assert!(result.is_ok());
         let import = result.unwrap();
 
@@ -420,9 +411,9 @@ mod tests {
         let memory = result.unwrap();
 
         // create an import object
-        let result = ImportObjectBuilder::<NeverType>::new()
+        let result = ImportObjectBuilder::new()
             .with_memory("memory", memory)
-            .build("extern");
+            .build::<NeverType>("extern", None);
         assert!(result.is_ok());
         let import = result.unwrap();
 
@@ -500,10 +491,10 @@ mod tests {
         let global_var = result.unwrap();
 
         // create an import object
-        let result = ImportObjectBuilder::<NeverType>::new()
+        let result = ImportObjectBuilder::new()
             .with_global("const-global", global_const)
             .with_global("var-global", global_var)
-            .build("extern");
+            .build::<NeverType>("extern", None);
         assert!(result.is_ok());
         let import = result.unwrap();
 
@@ -605,11 +596,11 @@ mod tests {
         let table = result.unwrap();
 
         // create an import object
-        let result = ImportObjectBuilder::<NeverType>::new()
+        let result = ImportObjectBuilder::new()
             .with_func::<(i32, i32), i32, NeverType>("add", real_add, None)
             .expect("failed to add host func")
             .with_table("table", table)
-            .build("extern");
+            .build::<NeverType>("extern", None);
         assert!(result.is_ok());
         let import = result.unwrap();
 
@@ -732,13 +723,13 @@ mod tests {
         let table = result.unwrap();
 
         // create an ImportModule instance
-        let result = ImportObjectBuilder::<NeverType>::new()
+        let result = ImportObjectBuilder::new()
             .with_func::<(i32, i32), i32, NeverType>("add", real_add, None)
             .expect("failed to add host function")
             .with_global("global", global_const)
             .with_memory("memory", memory)
             .with_table("table", table)
-            .build("extern-module-send");
+            .build::<NeverType>("extern-module-send", None);
         assert!(result.is_ok());
         let import = result.unwrap();
 
@@ -850,13 +841,13 @@ mod tests {
         let table = result.unwrap();
 
         // create an import object
-        let result = ImportObjectBuilder::<NeverType>::new()
+        let result = ImportObjectBuilder::new()
             .with_func::<(i32, i32), i32, NeverType>("add", real_add, None)
             .expect("failed to add host function")
             .with_global("global", global_const)
             .with_memory("memory", memory)
             .with_table("table", table)
-            .build("extern-module-sync");
+            .build::<NeverType>("extern-module-sync", None);
         assert!(result.is_ok());
         let import = result.unwrap();
         let import = Arc::new(Mutex::new(import));

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -251,13 +251,13 @@ mod tests {
         let table = result.unwrap();
 
         // create an ImportModule instance
-        let result = ImportObjectBuilder::<NeverType>::new()
+        let result = ImportObjectBuilder::new()
             .with_func::<(i32, i32), i32, NeverType>("add", real_add, None)
             .expect("failed to add host function")
             .with_global("global", global_const)
             .with_memory("mem", memory)
             .with_table("table", table)
-            .build("extern-module");
+            .build::<NeverType>("extern-module", None);
         assert!(result.is_ok());
         let import = result.unwrap();
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -30,10 +30,10 @@ impl Store {
     /// # Error
     ///
     /// If fail to register the given [import object](crate::ImportObject), then an error is returned.
-    pub fn register_import_module<T: Send + Sync + Clone>(
+    pub fn register_import_module(
         &mut self,
         executor: &mut Executor,
-        import: &ImportObject<T>,
+        import: &ImportObject,
     ) -> WasmEdgeResult<()> {
         executor
             .inner
@@ -187,13 +187,13 @@ mod tests {
         let table = result.unwrap();
 
         // create an ImportModule instance
-        let result = ImportObjectBuilder::<NeverType>::new()
+        let result = ImportObjectBuilder::new()
             .with_func::<(i32, i32), i32, NeverType>("add", real_add, None)
             .expect("failed to add host function")
             .with_global("global", global_const)
             .with_memory("mem", memory)
             .with_table("table", table)
-            .build("extern-module");
+            .build::<NeverType>("extern-module", None);
         assert!(result.is_ok());
         let import = result.unwrap();
 
@@ -365,13 +365,13 @@ mod tests {
         let table = result.unwrap();
 
         // create an ImportModule instance
-        let result = ImportObjectBuilder::<NeverType>::new()
+        let result = ImportObjectBuilder::new()
             .with_func::<(i32, i32), i32, NeverType>("add", real_add, None)
             .expect("failed to add host function")
             .with_global("global", global_const)
             .with_memory("mem", memory)
             .with_table("table", table)
-            .build("extern-module");
+            .build::<NeverType>("extern-module", None);
         assert!(result.is_ok());
         let import = result.unwrap();
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -252,7 +252,7 @@ impl VmBuilder {
 ///     #[cfg(not(feature = "async"))]
 ///     {
 ///         // create a Vm context
-///         let vm = VmBuilder::new().build::<NeverType>()?;
+///         let vm = VmBuilder::new().build()?;
 ///
 ///         // register a wasm module from the given in-memory wasm bytes
 ///         let wasm_bytes = wat2wasm(

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -103,10 +103,8 @@ impl VmBuilder {
     ///
     /// If fail to create, then an error is returned.
     #[cfg(not(feature = "async"))]
-    pub fn build<T: Send + Sync + Clone>(mut self) -> WasmEdgeResult<Vm<T>> {
+    pub fn build(mut self) -> WasmEdgeResult<Vm> {
         // executor
-
-        use crate::NeverType;
         let executor = Executor::new(self.config.as_ref(), self.stat.as_mut())?;
 
         // store
@@ -134,7 +132,7 @@ impl VmBuilder {
                 if let Ok(wasi_module) = sys::WasiModule::create(None, None, None) {
                     vm.executor.inner.register_import_object(
                         &vm.store.inner,
-                        &sys::ImportObject::<NeverType>::Wasi(wasi_module.clone()),
+                        &sys::ImportObject::Wasi(wasi_module.clone()),
                     )?;
 
                     vm.builtin_host_instances.insert(
@@ -170,10 +168,8 @@ impl VmBuilder {
     ///
     /// If fail to create, then an error is returned.
     #[cfg(all(feature = "async", target_os = "linux"))]
-    pub fn build<T: Send + Sync + Clone>(mut self) -> WasmEdgeResult<Vm<T>> {
+    pub fn build(mut self) -> WasmEdgeResult<Vm> {
         // executor
-
-        use crate::NeverType;
         let executor = Executor::new(self.config.as_ref(), self.stat.as_mut())?;
 
         // store
@@ -201,7 +197,7 @@ impl VmBuilder {
                 if let Ok(wasi_module) = sys::AsyncWasiModule::create(None, None, None) {
                     vm.executor.inner.register_import_object(
                         &vm.store.inner,
-                        &sys::ImportObject::<NeverType>::AsyncWasi(wasi_module.clone()),
+                        &sys::ImportObject::AsyncWasi(wasi_module.clone()),
                     )?;
 
                     vm.builtin_host_instances.insert(
@@ -304,18 +300,18 @@ impl VmBuilder {
 /// }
 /// ```
 #[derive(Debug, Clone)]
-pub struct Vm<T: Send + Sync + Clone> {
+pub struct Vm {
     pub(crate) config: Option<Config>,
     stat: Option<Statistics>,
     executor: Executor,
     store: Store,
     named_instances: HashMap<String, Instance>,
     active_instance: Option<Instance>,
-    imports: Vec<ImportObject<T>>,
+    imports: Vec<ImportObject>,
     builtin_host_instances: HashMap<HostRegistration, HostRegistrationInstance>,
     plugin_host_instances: Vec<Instance>,
 }
-impl<T: Send + Sync + Clone> Vm<T> {
+impl Vm {
     /// Registers a [wasm module](crate::Module) into this vm as a named or active module [instance](crate::Instance).
     ///
     /// # Arguments
@@ -406,7 +402,7 @@ impl<T: Send + Sync + Clone> Vm<T> {
     /// # Error
     ///
     /// If fail to register, then an error is returned.
-    pub fn register_import_module(mut self, import: ImportObject<T>) -> WasmEdgeResult<Self> {
+    pub fn register_import_module(mut self, import: ImportObject) -> WasmEdgeResult<Self> {
         match &import.0 {
             sys::ImportObject::Import(_) => {
                 self.store
@@ -872,7 +868,7 @@ mod tests {
     #[test]
     fn test_vm_run_func_from_file() {
         // create a Vm context
-        let result = VmBuilder::new().build::<NeverType>();
+        let result = VmBuilder::new().build();
         assert!(result.is_ok());
         let mut vm = result.unwrap();
 
@@ -892,7 +888,7 @@ mod tests {
     #[test]
     fn test_vm_run_func_from_bytes() {
         // create a Vm context
-        let result = VmBuilder::new().build::<NeverType>();
+        let result = VmBuilder::new().build();
         assert!(result.is_ok());
         let mut vm = result.unwrap();
 
@@ -945,7 +941,7 @@ mod tests {
     #[test]
     fn test_vm_run_func_from_module() {
         // create a Vm context
-        let result = VmBuilder::new().build::<NeverType>();
+        let result = VmBuilder::new().build();
         assert!(result.is_ok());
         let mut vm = result.unwrap();
 
@@ -1000,7 +996,7 @@ mod tests {
     #[test]
     fn test_vm_run_func_in_named_module_instance() {
         // create a Vm context
-        let result = VmBuilder::new().build::<NeverType>();
+        let result = VmBuilder::new().build();
         assert!(result.is_ok());
         let vm = result.unwrap();
 
@@ -1056,7 +1052,7 @@ mod tests {
     #[test]
     fn test_vm_run_func_in_active_module_instance() {
         // create a Vm context
-        let result = VmBuilder::new().build::<NeverType>();
+        let result = VmBuilder::new().build();
         assert!(result.is_ok());
         let vm = result.unwrap();
 
@@ -1117,7 +1113,7 @@ mod tests {
     #[allow(clippy::assertions_on_result_states)]
     fn test_vm_create() {
         {
-            let result = VmBuilder::new().build::<NeverType>();
+            let result = VmBuilder::new().build();
             assert!(result.is_ok());
         }
 
@@ -1128,7 +1124,7 @@ mod tests {
             let config = result.unwrap();
 
             // create a Vm context
-            let result = VmBuilder::new().with_config(config).build::<NeverType>();
+            let result = VmBuilder::new().with_config(config).build();
             assert!(result.is_ok());
             let _vm = result.unwrap();
         }
@@ -1144,7 +1140,7 @@ mod tests {
         let config = result.unwrap();
 
         // create a vm with the config settings
-        let result = VmBuilder::new().with_config(config).build::<NeverType>();
+        let result = VmBuilder::new().with_config(config).build();
         assert!(result.is_ok());
         let vm = result.unwrap();
 
@@ -1171,7 +1167,7 @@ mod tests {
         let config = result.unwrap();
 
         // create a Vm context
-        let result = VmBuilder::new().with_config(config).build::<NeverType>();
+        let result = VmBuilder::new().with_config(config).build();
         assert!(result.is_ok());
         let _vm = result.unwrap();
 
@@ -1184,7 +1180,7 @@ mod tests {
     fn test_vm_register_module_from_file() {
         {
             // create a Vm context
-            let result = VmBuilder::new().build::<NeverType>();
+            let result = VmBuilder::new().build();
             assert!(result.is_ok());
             let vm = result.unwrap();
 
@@ -1202,7 +1198,7 @@ mod tests {
 
         {
             // create a Vm context
-            let result = VmBuilder::new().build::<NeverType>();
+            let result = VmBuilder::new().build();
             assert!(result.is_ok());
             let vm = result.unwrap();
 
@@ -1223,7 +1219,7 @@ mod tests {
     #[allow(clippy::assertions_on_result_states)]
     fn test_vm_register_module_from_bytes() {
         // create a Vm context
-        let result = VmBuilder::new().build::<NeverType>();
+        let result = VmBuilder::new().build();
         assert!(result.is_ok());
         let vm = result.unwrap();
 
@@ -1297,18 +1293,18 @@ mod tests {
         let table = result.unwrap();
 
         // create an ImportModule instance
-        let result = ImportObjectBuilder::<NeverType>::new()
+        let result = ImportObjectBuilder::new()
             .with_func::<(i32, i32), i32, NeverType>("add", real_add, None)
             .expect("failed to add host function")
             .with_global("global", global_const)
             .with_memory("mem", memory)
             .with_table("table", table)
-            .build("extern-module");
+            .build::<NeverType>("extern-module", None);
         assert!(result.is_ok());
         let import = result.unwrap();
 
         // create a Vm context
-        let result = VmBuilder::new().build::<NeverType>();
+        let result = VmBuilder::new().build();
         assert!(result.is_ok());
         let vm = result.unwrap();
 
@@ -1337,7 +1333,7 @@ mod tests {
     #[test]
     fn test_vm_register_named_module() {
         // create a Vm context
-        let result = VmBuilder::new().build::<NeverType>();
+        let result = VmBuilder::new().build();
         assert!(result.is_ok());
         let vm = result.unwrap();
 
@@ -1414,7 +1410,7 @@ mod tests {
     #[test]
     fn test_vm_register_active_module() {
         // create a Vm context
-        let result = VmBuilder::new().build::<NeverType>();
+        let result = VmBuilder::new().build();
         assert!(result.is_ok());
         let vm = result.unwrap();
 


### PR DESCRIPTION
In this PR, the following improvements are introduced:

- In `wasmedge-sys`, improve the design of `Function` and `ImportModule`.
- Correspondingly, `Func`, `ImportObjectBuilder`, `VmBuilder` and `Store` in `wasmedge-sdk` are refactored.