### PR TITLE
Add support for standalone static libraries

### DIFF
--- a/crates/async-wasi/src/snapshots/common/vfs/sync.rs
+++ b/crates/async-wasi/src/snapshots/common/vfs/sync.rs
@@ -111,7 +111,7 @@ impl WasiStdin {
 
     pub fn fd_pread(
         &mut self,
-        bufs: &mut [io::IoSliceMut<'_>],
+        bufs: &[io::IoSliceMut<'_>],
         offset: wasi_types::__wasi_filesize_t,
     ) -> Result<usize, Errno> {
         Err(Errno::__WASI_ERRNO_SPIPE)
@@ -224,13 +224,13 @@ impl WasiStdout {
         Err(Errno::__WASI_ERRNO_BADF)
     }
 
-    pub fn fd_read(&mut self, bufs: &mut [io::IoSliceMut<'_>]) -> Result<usize, Errno> {
+    pub fn fd_read(&mut self, bufs: &[io::IoSliceMut<'_>]) -> Result<usize, Errno> {
         Err(Errno::__WASI_ERRNO_BADF)
     }
 
     pub fn fd_pread(
         &mut self,
-        bufs: &mut [io::IoSliceMut<'_>],
+        bufs: &[io::IoSliceMut<'_>],
         offset: wasi_types::__wasi_filesize_t,
     ) -> Result<usize, Errno> {
         Err(Errno::__WASI_ERRNO_BADF)
@@ -343,13 +343,13 @@ impl WasiStderr {
         Err(Errno::__WASI_ERRNO_BADF)
     }
 
-    pub fn fd_read(&mut self, bufs: &mut [io::IoSliceMut<'_>]) -> Result<usize, Errno> {
+    pub fn fd_read(&mut self, bufs: &[io::IoSliceMut<'_>]) -> Result<usize, Errno> {
         Err(Errno::__WASI_ERRNO_BADF)
     }
 
     pub fn fd_pread(
         &mut self,
-        bufs: &mut [io::IoSliceMut<'_>],
+        bufs: &[io::IoSliceMut<'_>],
         offset: wasi_types::__wasi_filesize_t,
     ) -> Result<usize, Errno> {
         Err(Errno::__WASI_ERRNO_BADF)

--- a/crates/async-wasi/src/snapshots/preview_1/async_poll.rs
+++ b/crates/async-wasi/src/snapshots/preview_1/async_poll.rs
@@ -98,7 +98,7 @@ async fn wait_fd(fd: &AsyncWasiSocket, type_: SubscriptionFdType) -> Result<__wa
 }
 
 async fn poll_only_fd<M: Memory>(
-    ctx: &mut WasiCtx,
+    ctx: &WasiCtx,
     mem: &mut M,
     out_ptr: WasmPtr<__wasi_event_t>,
     nsubscriptions: usize,
@@ -161,7 +161,7 @@ async fn poll_only_fd<M: Memory>(
 }
 
 async fn poll_fd_timeout<M: Memory>(
-    ctx: &mut WasiCtx,
+    ctx: &WasiCtx,
     mem: &mut M,
     out_ptr: WasmPtr<__wasi_event_t>,
     nsubscriptions: usize,

--- a/crates/async-wasi/src/snapshots/preview_1/async_socket.rs
+++ b/crates/async-wasi/src/snapshots/preview_1/async_socket.rs
@@ -80,7 +80,7 @@ pub fn sock_open<M: Memory>(
 
 pub fn sock_bind<M: Memory>(
     ctx: &mut WasiCtx,
-    mem: &mut M,
+    mem: &M,
     fd: __wasi_fd_t,
     addr_ptr: WasmPtr<__wasi_address_t>,
     port: u32,
@@ -579,7 +579,7 @@ pub fn sock_getsockopt<M: Memory>(
 
 pub fn sock_setsockopt<M: Memory>(
     ctx: &mut WasiCtx,
-    mem: &mut M,
+    mem: &M,
     fd: __wasi_fd_t,
     level: __wasi_sock_opt_level_t::Type,
     name: __wasi_sock_opt_so_t::Type,

--- a/crates/async-wasi/src/snapshots/preview_1/mod.rs
+++ b/crates/async-wasi/src/snapshots/preview_1/mod.rs
@@ -18,7 +18,7 @@ pub mod async_poll;
 pub mod async_socket;
 
 pub fn args_get<M: Memory>(
-    ctx: &mut WasiCtx,
+    ctx: &WasiCtx,
     mem: &mut M,
     argv: WasmPtr<__wasi_size_t>,
     argv_buf: WasmPtr<u8>,
@@ -38,7 +38,7 @@ pub fn args_get<M: Memory>(
 }
 
 pub fn args_sizes_get<M: Memory>(
-    ctx: &mut WasiCtx,
+    ctx: &WasiCtx,
     mem: &mut M,
     argc: WasmPtr<__wasi_size_t>,
     argv_buf_size: WasmPtr<__wasi_size_t>,
@@ -60,7 +60,7 @@ pub fn args_sizes_get<M: Memory>(
 }
 
 pub fn environ_get<M: Memory>(
-    ctx: &mut WasiCtx,
+    ctx: &WasiCtx,
     mem: &mut M,
     environ: WasmPtr<__wasi_size_t>,
     environ_buf: WasmPtr<u8>,
@@ -81,7 +81,7 @@ pub fn environ_get<M: Memory>(
 }
 
 pub fn environ_sizes_get<M: Memory>(
-    ctx: &mut WasiCtx,
+    ctx: &WasiCtx,
     mem: &mut M,
     environ_count: WasmPtr<__wasi_size_t>,
     environ_buf_size: WasmPtr<__wasi_size_t>,
@@ -118,7 +118,7 @@ pub fn clock_res_get<M: Memory>(
 }
 
 pub fn clock_time_get<M: Memory>(
-    ctx: &mut WasiCtx,
+    ctx: &WasiCtx,
     mem: &mut M,
     clock_id: __wasi_clockid_t::Type,
     precision: __wasi_timestamp_t,
@@ -480,8 +480,8 @@ pub fn fd_pread<M: Memory>(
             mem.write_data(nread, n.to_le())
         }
         VFD::Inode(INode::Stdin(fs)) => {
-            let mut bufs = mem.mut_iovec(iovs, iovs_len)?;
-            let n = fs.fd_pread(&mut bufs, offset)? as __wasi_size_t;
+            let bufs = mem.mut_iovec(iovs, iovs_len)?;
+            let n = fs.fd_pread(&bufs, offset)? as __wasi_size_t;
             mem.write_data(nread, n.to_le())
         }
         _ => Err(Errno::__WASI_ERRNO_BADF),
@@ -579,7 +579,7 @@ pub fn fd_readdir<M: Memory>(
 
 pub fn path_create_directory<M: Memory>(
     ctx: &mut WasiCtx,
-    mem: &mut M,
+    mem: &M,
     dirfd: __wasi_fd_t,
     path_ptr: WasmPtr<u8>,
     path_len: __wasi_size_t,
@@ -714,7 +714,7 @@ pub fn path_readlink<M: Memory>(
 
 pub fn path_remove_directory<M: Memory>(
     ctx: &mut WasiCtx,
-    mem: &mut M,
+    mem: &M,
     dirfd: __wasi_fd_t,
     path_ptr: WasmPtr<u8>,
     path_len: __wasi_size_t,
@@ -733,8 +733,8 @@ pub fn path_remove_directory<M: Memory>(
 }
 
 pub fn path_rename<M: Memory>(
-    ctx: &mut WasiCtx,
-    mem: &mut M,
+    ctx: &WasiCtx,
+    mem: &M,
     old_fd: __wasi_fd_t,
     old_path: WasmPtr<u8>,
     old_path_len: __wasi_size_t,
@@ -780,7 +780,7 @@ pub fn path_symlink<M: Memory>(
 
 pub fn path_unlink_file<M: Memory>(
     ctx: &mut WasiCtx,
-    mem: &mut M,
+    mem: &M,
     dirfd: __wasi_fd_t,
     path_ptr: WasmPtr<u8>,
     path_len: __wasi_size_t,

--- a/crates/wasmedge-sys/src/async_wasi.rs
+++ b/crates/wasmedge-sys/src/async_wasi.rs
@@ -819,7 +819,7 @@ pub fn path_create_directory(
 ) -> std::result::Result<Vec<WasmValue>, HostFuncError> {
     let data = data.unwrap();
 
-    let mut mem = frame.memory_mut(0).ok_or(HostFuncError::Runtime(0x88))?;
+    let mem = frame.memory_mut(0).ok_or(HostFuncError::Runtime(0x88))?;
 
     if let Some([p1, p2, p3]) = args.get(0..3) {
         let dirfd = p1.to_i32();
@@ -828,7 +828,7 @@ pub fn path_create_directory(
 
         Ok(to_wasm_return(p::path_create_directory(
             data,
-            &mut mem,
+            &mem,
             dirfd,
             WasmPtr::from(path_ptr),
             path_len,
@@ -949,7 +949,7 @@ pub fn path_remove_directory(
 ) -> std::result::Result<Vec<WasmValue>, HostFuncError> {
     let data = data.unwrap();
 
-    let mut mem = frame.memory_mut(0).ok_or(HostFuncError::Runtime(0x88))?;
+    let mem = frame.memory_mut(0).ok_or(HostFuncError::Runtime(0x88))?;
 
     if let Some([p1, p2, p3]) = args.get(0..3) {
         let fd = p1.to_i32();
@@ -958,7 +958,7 @@ pub fn path_remove_directory(
 
         Ok(to_wasm_return(p::path_remove_directory(
             data,
-            &mut mem,
+            &mem,
             fd,
             WasmPtr::from(path_ptr),
             path_len,
@@ -976,7 +976,7 @@ pub fn path_rename(
 ) -> std::result::Result<Vec<WasmValue>, HostFuncError> {
     let data = data.unwrap();
 
-    let mut mem = frame.memory_mut(0).ok_or(HostFuncError::Runtime(0x88))?;
+    let mem = frame.memory_mut(0).ok_or(HostFuncError::Runtime(0x88))?;
 
     if let Some([p1, p2, p3, p4, p5, p6]) = args.get(0..6) {
         let old_fd = p1.to_i32();
@@ -988,7 +988,7 @@ pub fn path_rename(
 
         Ok(to_wasm_return(p::path_rename(
             data,
-            &mut mem,
+            &mem,
             old_fd,
             WasmPtr::from(old_path),
             old_path_len,
@@ -1020,7 +1020,7 @@ pub fn path_unlink_file(
 ) -> std::result::Result<Vec<WasmValue>, HostFuncError> {
     let data = data.unwrap();
 
-    let mut mem = frame.memory_mut(0).ok_or(HostFuncError::Runtime(0x88))?;
+    let mem = frame.memory_mut(0).ok_or(HostFuncError::Runtime(0x88))?;
 
     if let Some([p1, p2, p3]) = args.get(0..3) {
         let fd = p1.to_i32();
@@ -1029,7 +1029,7 @@ pub fn path_unlink_file(
 
         Ok(to_wasm_return(p::path_unlink_file(
             data,
-            &mut mem,
+            &mem,
             fd,
             WasmPtr::from(path_ptr),
             path_len,
@@ -1118,7 +1118,7 @@ pub fn sock_bind(
 ) -> std::result::Result<Vec<WasmValue>, HostFuncError> {
     let data = data.unwrap();
 
-    let mut mem = frame.memory_mut(0).ok_or(HostFuncError::Runtime(0x88))?;
+    let mem = frame.memory_mut(0).ok_or(HostFuncError::Runtime(0x88))?;
 
     if let Some([p1, p2, p3]) = args.get(0..3) {
         let fd = p1.to_i32();
@@ -1126,7 +1126,7 @@ pub fn sock_bind(
         let port = p3.to_i32() as u32;
         Ok(to_wasm_return(p::async_socket::sock_bind(
             data,
-            &mut mem,
+            &mem,
             fd,
             WasmPtr::from(addr_ptr),
             port,
@@ -1469,7 +1469,7 @@ pub fn sock_setsockopt(
 ) -> std::result::Result<Vec<WasmValue>, HostFuncError> {
     let data = data.unwrap();
 
-    let mut mem = frame.memory_mut(0).ok_or(HostFuncError::Runtime(0x88))?;
+    let mem = frame.memory_mut(0).ok_or(HostFuncError::Runtime(0x88))?;
 
     if let Some([p1, p2, p3, p4, p5]) = args.get(0..5) {
         let fd = p1.to_i32();
@@ -1479,7 +1479,7 @@ pub fn sock_setsockopt(
         let flag_size = p5.to_i32() as u32;
         Ok(to_wasm_return(p::async_socket::sock_setsockopt(
             data,
-            &mut mem,
+            &mem,
             fd,
             level,
             name,

--- a/crates/wasmedge-sys/src/executor.rs
+++ b/crates/wasmedge-sys/src/executor.rs
@@ -69,7 +69,7 @@ impl Executor {
     /// If fail to register the given [import object](crate::ImportObject), then an error is returned.
     pub fn register_import_object<T: Send + Sync + Clone>(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         import: &ImportObject<T>,
     ) -> WasmEdgeResult<()> {
         match import {
@@ -118,7 +118,7 @@ impl Executor {
     /// If fail to register the given [module](crate::Module), then an error is returned.
     pub fn register_named_module(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         module: &Module,
         name: impl AsRef<str>,
     ) -> WasmEdgeResult<Instance> {
@@ -157,7 +157,7 @@ impl Executor {
     /// If fail to instantiate the given [module](crate::Module), then an error is returned.
     pub fn register_active_module(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         module: &Module,
     ) -> WasmEdgeResult<Instance> {
         let mut instance_ctx = std::ptr::null_mut();
@@ -189,7 +189,7 @@ impl Executor {
     /// If fail to register the given plugin module instance, then an error is returned.
     pub fn register_plugin_instance(
         &mut self,
-        store: &mut Store,
+        store: &Store,
         instance: &Instance,
     ) -> WasmEdgeResult<()> {
         unsafe {

--- a/crates/wasmedge-sys/src/instance/function.rs
+++ b/crates/wasmedge-sys/src/instance/function.rs
@@ -626,7 +626,7 @@ impl Function {
 
     pub fn call<E: Engine>(
         &self,
-        engine: &mut E,
+        engine: &E,
         args: impl IntoIterator<Item = WasmValue>,
     ) -> WasmEdgeResult<Vec<WasmValue>> {
         engine.run_func(self, args)
@@ -909,7 +909,7 @@ impl FuncRef {
     ///
     pub fn call<E: Engine>(
         &self,
-        engine: &mut E,
+        engine: &E,
         args: impl IntoIterator<Item = WasmValue>,
     ) -> WasmEdgeResult<Vec<WasmValue>> {
         engine.run_func_ref(self, args)

--- a/src/store.rs
+++ b/src/store.rs
@@ -37,7 +37,7 @@ impl Store {
     ) -> WasmEdgeResult<()> {
         executor
             .inner
-            .register_import_object(&mut self.inner, import.inner_ref())
+            .register_import_object(&self.inner, import.inner_ref())
     }
 
     /// Registers and instantiates a WasmEdge [compiled module](crate::Module) into this [store](crate::Store) as a named [module instance](crate::Instance), and returns the module instance.
@@ -61,11 +61,10 @@ impl Store {
         mod_name: impl AsRef<str>,
         module: &Module,
     ) -> WasmEdgeResult<Instance> {
-        let inner_instance = executor.inner.register_named_module(
-            &mut self.inner,
-            &module.inner,
-            mod_name.as_ref(),
-        )?;
+        let inner_instance =
+            executor
+                .inner
+                .register_named_module(&self.inner, &module.inner, mod_name.as_ref())?;
         Ok(Instance {
             inner: inner_instance,
         })
@@ -89,7 +88,7 @@ impl Store {
     ) -> WasmEdgeResult<Instance> {
         let inner = executor
             .inner
-            .register_active_module(&mut self.inner, &module.inner)?;
+            .register_active_module(&self.inner, &module.inner)?;
 
         Ok(Instance { inner })
     }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -133,7 +133,7 @@ impl VmBuilder {
             if cfg.wasi_enabled() {
                 if let Ok(wasi_module) = sys::WasiModule::create(None, None, None) {
                     vm.executor.inner.register_import_object(
-                        &mut vm.store.inner,
+                        &vm.store.inner,
                         &sys::ImportObject::<NeverType>::Wasi(wasi_module.clone()),
                     )?;
 
@@ -153,7 +153,7 @@ impl VmBuilder {
                 Some(instance) => {
                     vm.plugin_host_instances.push(instance);
                     vm.executor.inner.register_plugin_instance(
-                        &mut vm.store.inner,
+                        &vm.store.inner,
                         &vm.plugin_host_instances.last().unwrap().inner,
                     )?;
                 }
@@ -200,7 +200,7 @@ impl VmBuilder {
             if cfg.wasi_enabled() {
                 if let Ok(wasi_module) = sys::AsyncWasiModule::create(None, None, None) {
                     vm.executor.inner.register_import_object(
-                        &mut vm.store.inner,
+                        &vm.store.inner,
                         &sys::ImportObject::<NeverType>::AsyncWasi(wasi_module.clone()),
                     )?;
 
@@ -220,7 +220,7 @@ impl VmBuilder {
                 Some(instance) => {
                     vm.plugin_host_instances.push(instance);
                     vm.executor.inner.register_plugin_instance(
-                        &mut vm.store.inner,
+                        &vm.store.inner,
                         &vm.plugin_host_instances.last().unwrap().inner,
                     )?;
                 }
@@ -436,7 +436,7 @@ impl<T: Send + Sync + Clone> Vm<T> {
                     if let Some(mod_instance) = plugin.mod_instance(mod_name) {
                         self.plugin_host_instances.push(mod_instance);
                         self.executor.inner.register_plugin_instance(
-                            &mut self.store.inner,
+                            &self.store.inner,
                             &self.plugin_host_instances.last().unwrap().inner,
                         )?;
                     }


### PR DESCRIPTION
WasmEdge started releasing static libraries https://github.com/WasmEdge/WasmEdge/issues/2660
The `wasmedge-sys` crate support a `standalone` feature when using shared libraries.
This PR adds support for the `standalone` feature with static libraries.