### PR TITLE
[refactor] Update the APIs related to sync host function creation

### DIFF
--- a/crates/wasmedge-sys/examples/context_data_to_host_func.rs
+++ b/crates/wasmedge-sys/examples/context_data_to_host_func.rs
@@ -1,3 +1,4 @@
+use wasmedge_macro::sys_host_function;
 use wasmedge_sys::{CallingFrame, Executor, FuncType, Function, WasmValue};
 use wasmedge_types::{error::HostFuncError, ValType};
 
@@ -9,15 +10,15 @@ struct Data<T, S> {
     _s: Vec<S>,
 }
 
+#[sys_host_function]
 fn real_add<T: core::fmt::Debug>(
     _frame: CallingFrame,
     input: Vec<WasmValue>,
-    data: *mut std::ffi::c_void,
+    data: &mut Data<i32, &str>,
 ) -> Result<Vec<WasmValue>, HostFuncError> {
     println!("Rust: Entering Rust function real_add");
 
-    let host_data = unsafe { Box::from_raw(data as *mut T) };
-    println!("host_data: {:?}", host_data);
+    println!("data: {data:?}");
 
     if input.len() != 2 {
         return Err(HostFuncError::User(1));
@@ -43,7 +44,7 @@ fn real_add<T: core::fmt::Debug>(
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let data: Data<i32, &str> = Data {
+    let mut data: Data<i32, &str> = Data {
         _x: 12,
         _y: "hello".to_string(),
         _v: vec![1, 2, 3],
@@ -55,12 +56,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert!(result.is_ok());
     let func_ty = result.unwrap();
     // create a host function
-    let result = Function::create_sync_func(
-        &func_ty,
-        Box::new(real_add::<Data<i32, &str>>),
-        Some(Box::new(data)),
-        0,
-    );
+    let result = Function::create_sync_func(&func_ty, Box::new(real_add), Some(&mut data), 0);
     assert!(result.is_ok());
     let host_func = result.unwrap();
 

--- a/crates/wasmedge-sys/src/instance/function.rs
+++ b/crates/wasmedge-sys/src/instance/function.rs
@@ -380,11 +380,11 @@ impl Function {
     pub fn create_sync_func<T>(
         ty: &FuncType,
         real_fn: BoxedFn,
-        data: Option<Box<T>>,
+        data: Option<&mut T>,
         cost: u64,
     ) -> WasmEdgeResult<Self> {
         let data = match data {
-            Some(d) => Box::into_raw(d) as *mut std::ffi::c_void,
+            Some(d) => d as *mut T as *mut std::os::raw::c_void,
             None => std::ptr::null_mut(),
         };
 
@@ -1009,22 +1009,22 @@ mod tests {
             _v: Vec<T>,
             _s: Vec<S>,
         }
-        let data: Data<i32, &str> = Data {
+        let mut data: Data<i32, &str> = Data {
             _x: 12,
             _y: "hello".to_string(),
             _v: vec![1, 2, 3],
             _s: vec!["macos", "linux", "windows"],
         };
 
+        #[sys_host_function]
         fn real_add<T: core::fmt::Debug>(
             _frame: CallingFrame,
             input: Vec<WasmValue>,
-            data: *mut std::ffi::c_void,
+            data: &mut Data<i32, &str>,
         ) -> Result<Vec<WasmValue>, HostFuncError> {
             println!("Rust: Entering Rust function real_add");
 
-            let host_data = unsafe { Box::from_raw(data as *mut T) };
-            println!("host_data: {:?}", host_data);
+            println!("data: {:?}", data);
 
             if input.len() != 2 {
                 return Err(HostFuncError::User(1));
@@ -1057,12 +1057,7 @@ mod tests {
         assert!(result.is_ok());
         let func_ty = result.unwrap();
         // create a host function
-        let result = Function::create_sync_func(
-            &func_ty,
-            Box::new(real_add::<Data<i32, &str>>),
-            Some(Box::new(data)),
-            0,
-        );
+        let result = Function::create_sync_func(&func_ty, Box::new(real_add), Some(&mut data), 0);
         assert!(result.is_ok());
         let host_func = result.unwrap();
 

--- a/src/externals/function.rs
+++ b/src/externals/function.rs
@@ -44,7 +44,7 @@ impl Func {
             + Send
             + Sync
             + 'static,
-        data: Option<Box<T>>,
+        data: Option<&mut T>,
     ) -> WasmEdgeResult<Self> {
         let boxed_func = Box::new(real_func);
         let inner = sys::Function::create_sync_func::<T>(&ty.clone().into(), boxed_func, data, 0)?;
@@ -76,7 +76,7 @@ impl Func {
             + Send
             + Sync
             + 'static,
-        data: Option<Box<T>>,
+        data: Option<&mut T>,
     ) -> WasmEdgeResult<Self>
     where
         Args: WasmValTypeList,

--- a/src/import.rs
+++ b/src/import.rs
@@ -54,7 +54,7 @@ impl ImportObjectBuilder {
             + Send
             + Sync
             + 'static,
-        data: Option<Box<D>>,
+        data: Option<&mut D>,
     ) -> WasmEdgeResult<Self>
     where
         Args: WasmValTypeList,
@@ -98,7 +98,7 @@ impl ImportObjectBuilder {
             + Send
             + Sync
             + 'static,
-        data: Option<Box<D>>,
+        data: Option<&mut D>,
     ) -> WasmEdgeResult<Self> {
         let boxed_func = Box::new(real_func);
         let inner_func = sys::Function::create_sync_func::<D>(&ty.into(), boxed_func, data, 0)?;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -268,7 +268,7 @@ impl<T: Send + Sync + Clone> PluginModuleBuilder<T> {
             + Send
             + Sync
             + 'static,
-        data: Option<Box<D>>,
+        data: Option<&mut D>,
     ) -> WasmEdgeResult<Self>
     where
         Args: WasmValTypeList,


### PR DESCRIPTION
In this PR, the following APIs are refactored:

- `wasmedge-sdk`
  - `Func::new`, `Func::wrap_func`
  - `ImportObjectBuilder::with_func`, `ImportObjectBuilder::with_func_by_type`
  - `PluginModuleBuilder::with_func`
- `wasmedge-sys`
  - `Function::create_sync_func`