### PR TITLE
Add options to allow generating statically linked binaries

### DIFF
--- a/crates/wasmedge-sys/build_standalone.rs
+++ b/crates/wasmedge-sys/build_standalone.rs
@@ -108,7 +108,7 @@ fn get_remote_archive() -> Archive {
 
 fn do_http_request(url: &str) -> impl std::io::Read {
     let builder = reqwest::blocking::Client::builder();
-    let builder = match Env("STANDALONE_PROXY").lossy() {
+    let builder = match Env("WASMEDGE_STANDALONE_PROXY").lossy() {
         Some(proxy) => {
             debug!("using proxy to download archive: {proxy}");
             let proxy = reqwest::Proxy::all(proxy).expect("failed to parse proxy");


### PR DESCRIPTION
It is currently not possible to generate statically linked binaries since dependent libraries are dynamically linked (this is the default behaviour of `rustc-link-lib`).
Moreover, `rust-bindgen` fails to run in alpine when the `runtime` feature is enabled.

This PR add options to specify the type of linking required for the different dependencies using environment variables and removes the `runtime` feature from bindgen.