### PR TITLE
Add options to allow generating statically linked binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ WasmEdge Rust SDK provides idiomatic [Rust](https://www.rust-lang.org/) language
 
 ## Get Started
 
-Since this crate depends on the WasmEdge C API, it needs to be installed in your system first. Please refer to [Install and uninstall WasmEdge](https://wasmedge.org/docs/start/install) to install the WasmEdge library. The versioning table below shows the version of the WasmEdge library required by each version of the `wasmedge-sdk` crate.
+This crate depends on the WasmEdge C API. In linux/macOS the crate can download the API at build time by enabling the `standalone` feature. Otherwise the API needs to be installed in your system first. Please refer to [Install and uninstall WasmEdge](https://wasmedge.org/docs/start/install) to install the WasmEdge library. The versioning table below shows the version of the WasmEdge library required by each version of the `wasmedge-sdk` crate.
 
   | wasmedge-sdk  | WasmEdge lib  | wasmedge-sys  | wasmedge-types| wasmedge-macro| async-wasi|
   | :-----------: | :-----------: | :-----------: | :-----------: | :-----------: | :-------: |
@@ -31,12 +31,26 @@ Since this crate depends on the WasmEdge C API, it needs to be installed in your
   | 0.3.0         | 0.10.1        | 0.8           | 0.2           | -             | -         |
   | 0.1.0         | 0.10.0        | 0.7           | 0.1           | -             | -         |
 
-WasmEdge Rust SDK can automatically search the following paths for the WasmEdge library:
+WasmEdge Rust SDK will automatically search for the WasmEdge library in your system. Alternatively you can set the `WASMEDGE_DIR` environment variable to the path of the WasmEdge library (or the `WASMEDGE_INCLUDE_DIR` and `WASMEDGE_LIB_DIR` variables for more fine-grained control). If you want to use a local `cmake` build of WasmEdge you can set the `WASMEDGE_BUILD_DIR` instead.
 
-- `$HOME/.wasmedge` (Linux/macOS)
-- `/usr/local` (Linux/macOS)
+WasmEdge Rust SDK will search for the WasmEdge library in the following paths in order:
 
-If you have installed the WasmEdge library in a different path, you can set the `WASMEDGE_INCLUDE_DIR` and `WASMEDGE_LIB_DIR` environment variables to the path of the WasmEdge library.
+- `$WASMEDGE_[INCLUDE|LIB]_DIR`
+- `$WASMEDGE_DIR`
+- `$WASMEDGE_BUILD_DIR`
+- `$HOME/.wasmedge`
+- `/usr/local`
+- `$HOME/.local`
+
+When the `standalone` feature is enabled the correct library will be downloaded during build time and the previous locations are ignored. You can specify a proxy for the download process using the `WASMEDGE_STANDALONE_PROXY`, `WASMEDGE_STANDALONE_PROXY_USER` and `WASMEDGE_STANDALONE_PROXY_PASS` environment variables. You can set the `WASMEDGE_STANDALONE_ARCHIVE` environment variable to use a local archive instead of downloading one.
+The following architectures are supported for automatic downloads:
+  | os    | libc    | architecture        | linking type    |
+  | :---: | :-----: | :-----------------: | :-------------: |
+  | macos |         | `x86_64`, `aarch64` | dynamic         |
+  | linux | `glibc` | `x86_64`, `aarch64` | static, dynamic |
+  | linux | `musl`  | `x86_64`, `aarch64` | static          |
+
+This crate uses `rust-bindgen` during the build process. If you would like to use an external `rust-bindgen` you can set the `WASMEDGE_RUST_BINDGEN_PATH` environment variable to the `bindgen` executable path. This is particularly useful in systems like Alpine Linux (see [rust-lang/rust-bindgen#2360](https://github.com/rust-lang/rust-bindgen/issues/2360#issuecomment-1595869379), [rust-lang/rust-bindgen#2333](https://github.com/rust-lang/rust-bindgen/issues/2333)).
 
 **Notice:** The minimum supported Rust version is 1.68.
 

--- a/crates/async-wasi/src/snapshots/preview_1/async_socket.rs
+++ b/crates/async-wasi/src/snapshots/preview_1/async_socket.rs
@@ -151,7 +151,7 @@ pub async fn sock_accept<M: Memory>(
 
 pub async fn sock_connect<M: Memory>(
     ctx: &mut WasiCtx,
-    mem: &mut M,
+    mem: &M,
     fd: __wasi_fd_t,
     addr_ptr: WasmPtr<__wasi_address_t>,
     port: u32,

--- a/crates/wasmedge-sys/README.md
+++ b/crates/wasmedge-sys/README.md
@@ -8,27 +8,7 @@ For developers, it is recommended that the APIs in `wasmedge-sys` are used to co
 
 ## Build
 
-To use or build the `wasmedge-sys` crate, the `WasmEdge` library is required. Please refer to [WasmEdge Installation and Uninstallation](https://wasmedge.org/book/en/quick_start/install.html) to install the `WasmEdge` library.
-
-* The following table provides the versioning information about each crate of WasmEdge Rust bindings.
-
-  | wasmedge-sdk  | WasmEdge lib  | wasmedge-sys  | wasmedge-types| wasmedge-macro| async-wasi|
-  | :-----------: | :-----------: | :-----------: | :-----------: | :-----------: | :-------: |
-  | 0.11.0        | 0.13.3        | 0.16.0        | 0.4.3         | 0.6.0         | 0.0.3     |
-  | 0.10.1        | 0.13.3        | 0.15.1        | 0.4.2         | 0.5.0         | 0.0.2     |
-  | 0.10.0        | 0.13.2        | 0.15.0        | 0.4.2         | 0.5.0         | 0.0.2     |
-  | 0.9.0         | 0.13.1        | 0.14.0        | 0.4.2         | 0.4.0         | 0.0.1     |
-  | 0.9.0         | 0.13.0        | 0.14.0        | 0.4.2         | 0.4.0         | 0.0.1     |
-  | 0.9.0         | 0.13.0        | 0.14.0        | 0.4.2         | 0.4.0         | 0.0.1     |
-  | 0.8.1         | 0.12.1        | 0.13.1        | 0.4.1         | 0.3.0         | -         |
-  | 0.8.0         | 0.12.0        | 0.13.0        | 0.4.1         | 0.3.0         | -         |
-  | 0.7.1         | 0.11.2        | 0.12.2        | 0.3.1         | 0.3.0         | -         |
-  | 0.7.0         | 0.11.2        | 0.12          | 0.3.1         | 0.3.0         | -         |
-  | 0.6.0         | 0.11.2        | 0.11          | 0.3.0         | 0.2.0         | -         |
-  | 0.5.0         | 0.11.1        | 0.10          | 0.3.0         | 0.1.0         | -         |
-  | 0.4.0         | 0.11.0        | 0.9           | 0.2.1         | -             | -         |
-  | 0.3.0         | 0.10.1        | 0.8           | 0.2           | -             | -         |
-  | 0.1.0         | 0.10.0        | 0.7           | 0.1           | -             | -         |
+This crate depends on the WasmEdge C API. In linux/macOS the crate can download the API at build time by enabling the `standalone` feature. Otherwise the API needs to be installed in your system first. Please refer to [Get Started](https://github.com/WasmEdge/wasmedge-rust-sdk#get-started) for more information.
 
 ## See also
 

--- a/crates/wasmedge-sys/build.rs
+++ b/crates/wasmedge-sys/build.rs
@@ -11,12 +11,21 @@ use crate::build_paths::AsPath;
 
 const WASMEDGE_RELEASE_VERSION: &str = "0.13.3";
 const REMOTE_ARCHIVES: phf::Map<&'static str, (&'static str, &'static str)> = phf_map! {
-    "macos/aarch64"         => ("db03037e2678e197f9cd5f01392ee088df07e7726849626190f2d4ec1dc693c9", "darwin_arm64"),
-    "macos/x86_64"          => ("f913ba51c69603d0c3409bbbbef1cd2a525ffccb9643fe2aea313a47c70cbea7", "darwin_x86_64"),
-    "linux/aarch64"         => ("82a6d5c686b34b15abab4f28f33099bcded11446563bb2bf0d8a22811304efa1", "manylinux2014_aarch64"),
-    "linux/x86_64"          => ("e3634df41375856fbf374f65e91a925c15821f78a4c93852bce5df053d1f2b2b", "manylinux2014_x86_64"),
-    "linux/aarch64/static"  => ("3fb21a5dace3dd46a3f28e0a0e4473c8e22526b083aba15d875afc28b1976cc9", "debian11_aarch64_static"),
-    "linux/x86_64/static"   => ("488d47c43653c0a079c034aa73e525dd60873af15967d6c1d82386862ba31baa", "debian11_x86_64_static"),
+    // The key is: {os}/{arch}[/{libc}][/static]
+    //  * The libc abi is only added on linux.
+    //  * "static" is added when the `static` feature is enabled.
+    //
+    // The value is a tuple containing the sha256sum of the archive, and the platform slug as it appears in the archive name:
+    //  * The archive name is WasmEdge-{version}-{slug}.tar.gz
+
+    "macos/aarch64"                => ("db03037e2678e197f9cd5f01392ee088df07e7726849626190f2d4ec1dc693c9", "darwin_arm64"),
+    "macos/x86_64"                 => ("f913ba51c69603d0c3409bbbbef1cd2a525ffccb9643fe2aea313a47c70cbea7", "darwin_x86_64"),
+    "linux/aarch64/gnu"            => ("82a6d5c686b34b15abab4f28f33099bcded11446563bb2bf0d8a22811304efa1", "manylinux2014_aarch64"),
+    "linux/x86_64/gnu"             => ("e3634df41375856fbf374f65e91a925c15821f78a4c93852bce5df053d1f2b2b", "manylinux2014_x86_64"),
+    "linux/aarch64/gnu/static"     => ("3fb21a5dace3dd46a3f28e0a0e4473c8e22526b083aba15d875afc28b1976cc9", "debian11_aarch64_static"),
+    "linux/x86_64/gnu/static"      => ("488d47c43653c0a079c034aa73e525dd60873af15967d6c1d82386862ba31baa", "debian11_x86_64_static"),
+    "linux/aarch64/musl/static"    => ("9a44c495ce8d9bcfb284dc2154d76a27165ad852d3a3a16a1578de1d2a765fb8", "alpine3.16_aarch64_static"),
+    "linux/x86_64/musl/static"     => ("a0ccfd944e5df5f89008a7158046e10ee84fe74406f9c44394e81f4e1ed23b02", "alpine3.16_x86_64_static"),
 };
 
 lazy_static! {

--- a/crates/wasmedge-sys/build_standalone.rs
+++ b/crates/wasmedge-sys/build_standalone.rs
@@ -108,7 +108,7 @@ fn get_remote_archive() -> Archive {
 
 fn do_http_request(url: &str) -> impl std::io::Read {
     let builder = reqwest::blocking::Client::builder();
-    let builder = match Env("STANDALONE_PROXY").lossy() {
+    let builder = match Env("WASMEDGE_STANDALONE_PROXY").lossy() {
         Some(proxy) => {
             debug!("using proxy to download archive: {proxy}");
             let proxy = reqwest::Proxy::all(proxy).expect("failed to parse proxy");

--- a/crates/wasmedge-sys/build_standalone.rs
+++ b/crates/wasmedge-sys/build_standalone.rs
@@ -88,11 +88,15 @@ pub fn get_standalone_libwasmedge() -> std::path::PathBuf {
 fn get_remote_archive() -> Archive {
     let os = Env("CARGO_CFG_TARGET_OS").expect_lossy("failed to read CARGO_CFG_TARGET_OS");
     let arch = Env("CARGO_CFG_TARGET_ARCH").expect_lossy("failed to read CARGO_CFG_TARGET_ARCH");
-    let target = if cfg!(feature = "static") {
-        format!("{os}/{arch}/static")
-    } else {
-        format!("{os}/{arch}")
-    };
+    let libc = Env("CARGO_CFG_TARGET_ENV").expect_lossy("failed to read CARGO_CFG_TARGET_ENV");
+
+    let mut target = format!("{os}/{arch}");
+    if os == "linux" && !libc.is_empty() {
+        target = target + "/" + &libc;
+    }
+    if cfg!(feature = "static") {
+        target += "/static";
+    }
 
     debug!("building archive url for target {target}");
     let (sha, slug) = REMOTE_ARCHIVES

--- a/crates/wasmedge-sys/src/async/module.rs
+++ b/crates/wasmedge-sys/src/async/module.rs
@@ -1297,7 +1297,7 @@ pub async fn sock_connect(
 ) -> Result<Vec<WasmValue>, HostFuncError> {
     let data = data.unwrap();
 
-    let mut mem = frame.memory_mut(0).ok_or(HostFuncError::Runtime(0x88))?;
+    let mem = frame.memory_mut(0).ok_or(HostFuncError::Runtime(0x88))?;
 
     if let Some([p1, p2, p3]) = args.get(0..3) {
         let fd = p1.to_i32();
@@ -1305,7 +1305,7 @@ pub async fn sock_connect(
         let port = p3.to_i32() as u32;
 
         Ok(to_wasm_return(
-            p::async_socket::sock_connect(data, &mut mem, fd, WasmPtr::from(addr_ptr), port).await,
+            p::async_socket::sock_connect(data, &mem, fd, WasmPtr::from(addr_ptr), port).await,
         ))
     } else {
         Err(HostFuncError::Runtime(0x83))

--- a/crates/wasmedge-sys/src/instance/function.rs
+++ b/crates/wasmedge-sys/src/instance/function.rs
@@ -442,7 +442,7 @@ impl Function {
     pub async fn call_async<E: Engine + Send + Sync>(
         &self,
         async_state: &AsyncState,
-        engine: &mut E,
+        engine: &E,
         args: impl IntoIterator<Item = WasmValue> + Send,
     ) -> WasmEdgeResult<Vec<WasmValue>> {
         FiberFuture::on_fiber(async_state, || engine.run_func(self, args))


### PR DESCRIPTION
It is currently not possible to generate statically linked binaries since dependent libraries are dynamically linked (this is the default behaviour of `rustc-link-lib`).

Moreover, `rust-bindgen` fails to run in alpine when the `runtime` feature is enabled, and fails to run with static or dynamic linking due to issues with `crt-static`. See https://github.com/rust-lang/rust-bindgen/issues/2333#issuecomment-1372584644.

This PR add:
* Options to specify the type of linking required for the different dependencies using environment variables.
* Adds an option to use an external `rust-bindgen` using environment variables.
* Adds support for musl libc following https://github.com/WasmEdge/WasmEdge/issues/2711.