### PR TITLE
[Feat] New API in `Store`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 thiserror = "1.0.30"
 wasmedge-macro.workspace = true
-wasmedge-sys = {path = "crates/wasmedge-sys", version = "0.16", default-features = false}
+wasmedge-sys = {path = "crates/wasmedge-sys", version = "0.17", default-features = false}
 wasmedge-types.workspace = true
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "wasmedge-sdk"
 readme = "README.md"
 repository = "https://github.com/WasmEdge/WasmEdge/blob/master/bindings/rust/wasmedge-sdk"
-version = "0.11.2"
+version = "0.12.0-dev"
 
 [dependencies]
 anyhow = "1.0"

--- a/crates/wasmedge-sys/Cargo.toml
+++ b/crates/wasmedge-sys/Cargo.toml
@@ -10,7 +10,7 @@ links = "wasmedge"
 name = "wasmedge-sys"
 readme = "README.md"
 repository = "https://github.com/WasmEdge/wasmedge-rust-sdk"
-version = "0.16.2"
+version = "0.17.0"
 
 [dependencies]
 fiber-for-wasmedge = {version = "8.0.1", optional = true}

--- a/crates/wasmedge-sys/src/plugin.rs
+++ b/crates/wasmedge-sys/src/plugin.rs
@@ -625,7 +625,7 @@ mod tests {
 
         // get `wasmedge_process` plugin
         let result = PluginManager::find("wasmedge_process");
-        assert!(result.is_some());
+        assert!(result.is_ok());
         let plugin = result.unwrap();
         assert_eq!(plugin.name(), "wasmedge_process");
         assert_eq!(plugin.mod_count(), 1);
@@ -633,7 +633,7 @@ mod tests {
 
         // get module instance from plugin
         let result = plugin.mod_instance("wasmedge_process");
-        assert!(result.is_some());
+        assert!(result.is_ok());
         let instance = result.unwrap();
 
         assert_eq!(instance.name().unwrap(), "wasmedge_process");

--- a/crates/wasmedge-sys/src/plugin.rs
+++ b/crates/wasmedge-sys/src/plugin.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use parking_lot::Mutex;
 use std::{ffi::CString, os::raw::c_void, sync::Arc};
-use wasmedge_types::error::{InstanceError, WasmEdgeError};
+use wasmedge_types::error::{InstanceError, PluginError, WasmEdgeError};
 
 /// Defines the APIs for loading plugins and check the basic information of the loaded plugins.
 #[derive(Debug)]
@@ -68,14 +68,16 @@ impl PluginManager {
     /// # Argument
     ///
     /// * `name` - The name of the target plugin.
-    pub fn find(name: impl AsRef<str>) -> Option<Plugin> {
+    pub fn find(name: impl AsRef<str>) -> WasmEdgeResult<Plugin> {
         let plugin_name: WasmEdgeString = name.as_ref().into();
 
         let ctx = unsafe { ffi::WasmEdge_PluginFind(plugin_name.as_raw()) };
 
         match ctx.is_null() {
-            true => None,
-            false => Some(Plugin {
+            true => Err(Box::new(WasmEdgeError::Plugin(PluginError::Load(
+                name.as_ref().into(),
+            )))),
+            false => Ok(Plugin {
                 inner: InnerPlugin(ctx as *mut _),
             }),
         }
@@ -146,19 +148,25 @@ impl Plugin {
         names.into_iter().map(|x| x.into()).collect::<Vec<String>>()
     }
 
-    /// Returns a module instance that is generated from the module with the given name in this plugin.
+    /// Returns a plugin module instance that is generated from the module with the given name in this plugin.
     ///
     /// # Argument
     ///
     /// * `name` - The name of the target module.
-    pub fn mod_instance(&self, name: impl AsRef<str>) -> Option<Instance> {
+    ///
+    /// # Error
+    ///
+    /// If failed to return the plugin module instance, then return [PluginError::Create](wasmedge_types::error::PluginError::Create) error.
+    pub fn mod_instance(&self, name: impl AsRef<str>) -> WasmEdgeResult<Instance> {
         let mod_name: WasmEdgeString = name.as_ref().into();
 
         let ctx = unsafe { ffi::WasmEdge_PluginCreateModule(self.inner.0, mod_name.as_raw()) };
 
         match ctx.is_null() {
-            true => None,
-            false => Some(Instance {
+            true => Err(Box::new(WasmEdgeError::Plugin(PluginError::Create(
+                name.as_ref().into(),
+            )))),
+            false => Ok(Instance {
                 inner: Arc::new(Mutex::new(InnerInstance(ctx))),
                 registered: false,
             }),

--- a/crates/wasmedge-sys/src/plugin.rs
+++ b/crates/wasmedge-sys/src/plugin.rs
@@ -68,13 +68,17 @@ impl PluginManager {
     /// # Argument
     ///
     /// * `name` - The name of the target plugin.
+    ///
+    /// # Error
+    ///
+    /// If not found the plugin, then return [PluginError::NotFound](wasmedge_types::error::PluginError::NotFound) error.
     pub fn find(name: impl AsRef<str>) -> WasmEdgeResult<Plugin> {
         let plugin_name: WasmEdgeString = name.as_ref().into();
 
         let ctx = unsafe { ffi::WasmEdge_PluginFind(plugin_name.as_raw()) };
 
         match ctx.is_null() {
-            true => Err(Box::new(WasmEdgeError::Plugin(PluginError::Load(
+            true => Err(Box::new(WasmEdgeError::Plugin(PluginError::NotFound(
                 name.as_ref().into(),
             )))),
             false => Ok(Plugin {

--- a/crates/wasmedge-types/Cargo.toml
+++ b/crates/wasmedge-types/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "wasmedge-types"
 readme = "README.md"
 repository = "https://github.com/WasmEdge/wasmedge-rust-sdk"
-version = "0.4.3"
+version = "0.4.4"
 
 [dependencies]
 thiserror = "1.0.30"

--- a/crates/wasmedge-types/src/error.rs
+++ b/crates/wasmedge-types/src/error.rs
@@ -194,8 +194,8 @@ pub enum InstanceError {
 pub enum PluginError {
     #[error("Failed to create a plugin instance named '{0}'. Make sure that the plugin instance name is correct.")]
     Create(String),
-    #[error("Failed to load the plugin named '{0}'. Make sure that the plugin name is correct.")]
-    Load(String),
+    #[error("Not found the plugin named '{0}'. Make sure that the plugin name is correct.")]
+    NotFound(String),
 }
 
 /// The error types for WasmEdge Store.

--- a/crates/wasmedge-types/src/error.rs
+++ b/crates/wasmedge-types/src/error.rs
@@ -62,6 +62,8 @@ pub enum WasmEdgeError {
     Export(ExportError),
     #[error("{0}")]
     Instance(InstanceError),
+    #[error("{0}")]
+    Plugin(PluginError),
 
     // std
     #[error("Found an internal 0 byte")]
@@ -185,6 +187,15 @@ pub enum InstanceError {
     NotFoundGlobal(String),
     #[error("Not found the given mapped Fd/handler")]
     NotFoundMappedFdHandler,
+}
+
+/// The error types for WasmEdge plugin.
+#[derive(Error, Clone, Debug, PartialEq, Eq)]
+pub enum PluginError {
+    #[error("Failed to create a plugin instance named '{0}'. Make sure that the plugin instance name is correct.")]
+    Create(String),
+    #[error("Failed to load the plugin named '{0}'. Make sure that the plugin name is correct.")]
+    Load(String),
 }
 
 /// The error types for WasmEdge Store.

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -108,12 +108,14 @@ impl Plugin {
     /// # Argument
     ///
     /// * `name` - The name of the target module.
-    pub fn mod_instance(&self, name: impl AsRef<str>) -> Option<Instance> {
+    pub fn mod_instance(&self, name: impl AsRef<str>) -> Option<PluginInstance> {
         self.inner
             .mod_instance(name.as_ref())
             .map(|i| Instance { inner: i })
     }
 }
+
+pub type PluginInstance = Instance;
 
 /// Defines the type of the function that creates a module instance for a plugin.
 pub type ModuleInstanceCreateFn = sys::plugin::ModuleInstanceCreateFn;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -61,7 +61,11 @@ impl PluginManager {
     /// # Argument
     ///
     /// * `name` - The name of the target plugin.
-    pub fn find(name: impl AsRef<str>) -> Option<Plugin> {
+    ///
+    /// # Error
+    ///
+    /// If failed to return the plugin module instance, then return [PluginError::NotFound](wasmedge_types::error::PluginError::NotFound) error.
+    pub fn find(name: impl AsRef<str>) -> WasmEdgeResult<Plugin> {
         sys::plugin::PluginManager::find(name.as_ref()).map(|p| Plugin { inner: p })
     }
 
@@ -108,7 +112,11 @@ impl Plugin {
     /// # Argument
     ///
     /// * `name` - The name of the target module.
-    pub fn mod_instance(&self, name: impl AsRef<str>) -> Option<PluginInstance> {
+    ///
+    /// # Error
+    ///
+    /// If failed to return the plugin module instance, then return [PluginError::Create](wasmedge_types::error::PluginError::Create) error.
+    pub fn mod_instance(&self, name: impl AsRef<str>) -> WasmEdgeResult<PluginInstance> {
         self.inner
             .mod_instance(name.as_ref())
             .map(|i| Instance { inner: i })

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,6 +1,6 @@
 //! Defines WasmEdge Store struct.
 
-use crate::{Executor, ImportObject, Instance, Module, WasmEdgeResult};
+use crate::{plugin::PluginInstance, Executor, ImportObject, Instance, Module, WasmEdgeResult};
 use wasmedge_sys as sys;
 
 /// Represents all global state that can be manipulated by WebAssembly programs. A [store](crate::Store) consists of the runtime representation of all instances of [functions](crate::Func), [tables](crate::Table), [memories](crate::Memory), and [globals](crate::Global).
@@ -94,6 +94,27 @@ impl Store {
             .register_active_module(&self.inner, &module.inner)?;
 
         Ok(Instance { inner })
+    }
+
+    /// Registers a PluginInstance into this store.
+    ///
+    /// # Arguments
+    ///
+    /// * `executor` - The [executor](crate::Executor) that runs the host functions in this [store](crate::Store).
+    ///
+    /// * `plugin` - The WasmEdge [plugin instance](crate::plugin::PluginInstance) to be registered.
+    ///
+    /// # Error
+    ///
+    /// If fail to register the plugin instance, then an error is returned.
+    pub fn register_plugin_module(
+        &mut self,
+        executor: &mut Executor,
+        plugin: &PluginInstance,
+    ) -> WasmEdgeResult<()> {
+        executor
+            .inner
+            .register_plugin_instance(&self.inner, &plugin.inner)
     }
 
     /// Returns the number of the named [module instances](crate::Instance) in this [store](crate::Store).

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -154,7 +154,7 @@ impl VmBuilder {
             vm.plugin_host_instances.push(plugin_instance);
             vm.store.register_plugin_module(
                 &mut vm.executor,
-                &vm.plugin_host_instances.last().unwrap(),
+                vm.plugin_host_instances.last().unwrap(),
             )?;
         }
 
@@ -231,7 +231,7 @@ impl VmBuilder {
             vm.plugin_host_instances.push(plugin_instance);
             vm.store.register_plugin_module(
                 &mut vm.executor,
-                &vm.plugin_host_instances.last().unwrap(),
+                vm.plugin_host_instances.last().unwrap(),
             )?;
         }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -7,6 +7,7 @@ use crate::wasi::WasiInstance;
 use crate::{
     config::Config,
     error::{VmError, WasmEdgeError},
+    plugin::{PluginInstance, PluginManager},
     Executor, HostRegistration, ImportObject, Instance, Module, Statistics, Store, WasmEdgeResult,
     WasmValue,
 };
@@ -149,16 +150,12 @@ impl VmBuilder {
 
         // * load and register plugin instances
         for (pname, mname) in self.plugins.iter() {
-            match Self::create_plugin_instance(pname, mname) {
-                Some(instance) => {
-                    vm.plugin_host_instances.push(instance);
-                    vm.executor.inner.register_plugin_instance(
-                        &vm.store.inner,
-                        &vm.plugin_host_instances.last().unwrap().inner,
-                    )?;
-                }
-                None => panic!("Not found {}::{} plugin", pname, mname),
-            }
+            let plugin_instance = Self::create_plugin_instance(pname, mname)?;
+            vm.plugin_host_instances.push(plugin_instance);
+            vm.store.register_plugin_module(
+                &mut vm.executor,
+                &vm.plugin_host_instances.last().unwrap(),
+            )?;
         }
 
         Ok(vm)
@@ -230,26 +227,23 @@ impl VmBuilder {
 
         // * load and register plugin instances
         for (pname, mname) in self.plugins.iter() {
-            match Self::create_plugin_instance(pname, mname) {
-                Some(instance) => {
-                    vm.plugin_host_instances.push(instance);
-                    vm.executor.inner.register_plugin_instance(
-                        &vm.store.inner,
-                        &vm.plugin_host_instances.last().unwrap().inner,
-                    )?;
-                }
-                None => panic!("Not found {}::{} plugin", pname, mname),
-            }
+            let plugin_instance = Self::create_plugin_instance(pname, mname)?;
+            vm.plugin_host_instances.push(plugin_instance);
+            vm.store.register_plugin_module(
+                &mut vm.executor,
+                &vm.plugin_host_instances.last().unwrap(),
+            )?;
         }
 
         Ok(vm)
     }
 
-    fn create_plugin_instance(pname: impl AsRef<str>, mname: impl AsRef<str>) -> Option<Instance> {
-        match crate::plugin::PluginManager::find(pname.as_ref()) {
-            Some(plugin) => plugin.mod_instance(mname.as_ref()),
-            None => None,
-        }
+    fn create_plugin_instance(
+        pname: impl AsRef<str>,
+        mname: impl AsRef<str>,
+    ) -> WasmEdgeResult<PluginInstance> {
+        let plugin = PluginManager::find(pname.as_ref())?;
+        plugin.mod_instance(mname.as_ref())
     }
 }
 
@@ -326,7 +320,7 @@ pub struct Vm {
     named_instances: HashMap<String, Instance>,
     active_instance: Option<Instance>,
     builtin_host_instances: HashMap<HostRegistration, HostRegistrationInstance>,
-    plugin_host_instances: Vec<Instance>,
+    plugin_host_instances: Vec<PluginInstance>,
 }
 impl Vm {
     /// Registers a [wasm module](crate::Module) into this vm as a named or active module [instance](crate::Instance).
@@ -439,10 +433,10 @@ impl Vm {
     ///
     /// If fail to register plugin instance, then an error is returned.
     pub fn auto_detect_plugins(mut self) -> WasmEdgeResult<Self> {
-        for plugin_name in crate::plugin::PluginManager::names().iter() {
-            if let Some(plugin) = crate::plugin::PluginManager::find(plugin_name) {
+        for plugin_name in PluginManager::names().iter() {
+            if let Ok(plugin) = PluginManager::find(plugin_name) {
                 for mod_name in plugin.mod_names().iter() {
-                    if let Some(mod_instance) = plugin.mod_instance(mod_name) {
+                    if let Ok(mod_instance) = plugin.mod_instance(mod_name) {
                         self.plugin_host_instances.push(mod_instance);
                         self.executor.inner.register_plugin_instance(
                             &self.store.inner,


### PR DESCRIPTION
In this PR, introduce a new API `register_plugin_module` in `Store` and a new type alias `PluginInstance` in `plugin` mod. In addition, the following changes are also made in this PR:

- Introduce `PluginError` in `wasmedge_types::error` mod
- Refactor `PluginManager::find` and `Plugin::mod_instance` APIs
- Refactor `VmBuilder` and `Vm`