### PR TITLE
[CI] Update CI workflows

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -8,9 +8,15 @@ on:
   push:
     paths-ignore:
       - "**/*.md"
+      - ".github/workflows/publish*.yml"
+      - ".github/workflows/release*.yml"
+      - ".github/workflows/standalone.yml"
   pull_request:
     paths-ignore:
       - "**/*.md"
+      - ".github/workflows/publish*.yml"
+      - ".github/workflows/release*.yml"
+      - ".github/workflows/standalone.yml"
 
 jobs:
   build_ubuntu:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -8,14 +8,10 @@ on:
   push:
     paths-ignore:
       - "**/*.md"
-      - ".github/workflows/publish*.yml"
-      - ".github/workflows/release*.yml"
       - ".github/workflows/standalone.yml"
   pull_request:
     paths-ignore:
       - "**/*.md"
-      - ".github/workflows/publish*.yml"
-      - ".github/workflows/release*.yml"
       - ".github/workflows/standalone.yml"
 
 jobs:

--- a/.github/workflows/publish-async-api-docs.yml
+++ b/.github/workflows/publish-async-api-docs.yml
@@ -1,4 +1,4 @@
-name: wasmedge-sdk-release
+name: Publish Async API Documents
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -24,7 +24,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          path: wasmedge-rust-sdk
 
       - name: Set up build environment
         run: |
@@ -41,7 +40,6 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
 
       - name: Build Async API document
-        working-directory: wasmedge-rust-sdk
         run: |
           RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc -p wasmedge-sdk --workspace --no-deps --features aot,async,wasi_crypto,wasi_nn,wasmedge_process,ffi --target-dir=./target
 
@@ -51,5 +49,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
-          publish_dir: wasmedge-rust-sdk/target/doc
+          publish_dir: target/doc
           force_orphan: true

--- a/.github/workflows/release-async-wasi.yml
+++ b/.github/workflows/release-async-wasi.yml
@@ -1,4 +1,4 @@
-name: async-wasi-release
+name: Release async-wasi crate
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -18,7 +18,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          path: wasmedge-rust-sdk
 
       - name: Install Rust v1.68
         uses: dtolnay/rust-toolchain@stable
@@ -26,7 +25,6 @@ jobs:
           toolchain: 1.68
 
       - name: Dry run cargo publish
-        working-directory: wasmedge-rust-sdk
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRIES_ASYNC_WASI_TOKEN }}
         shell: bash
@@ -34,7 +32,6 @@ jobs:
           cargo publish --dry-run -p async-wasi
 
       - name: Publish
-        working-directory: wasmedge-rust-sdk
         if: github.ref == 'refs/heads/main'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRIES_ASYNC_WASI_TOKEN }}
@@ -44,7 +41,6 @@ jobs:
           cargo publish -p async-wasi
 
       - name: Build API document
-        working-directory: wasmedge-rust-sdk
         run: |
           cargo doc -p async-wasi --no-deps --target-dir=./target
 
@@ -54,5 +50,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
-          publish_dir: wasmedge-rust-sdk/target/doc
+          publish_dir: target/doc
           force_orphan: true

--- a/.github/workflows/release-wasmedge-macro.yml
+++ b/.github/workflows/release-wasmedge-macro.yml
@@ -1,4 +1,4 @@
-name: wasmedge-macro-release
+name: Release wasmedge-macro crate
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -18,7 +18,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          path: wasmedge-rust-sdk
 
       - name: Install Rust v1.68
         uses: dtolnay/rust-toolchain@stable
@@ -26,7 +25,6 @@ jobs:
           toolchain: 1.68
 
       - name: Dry run cargo publish
-        working-directory: wasmedge-rust-sdk
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRIES_MACRO_TOKEN }}
         shell: bash
@@ -34,7 +32,6 @@ jobs:
           cargo publish --dry-run -p wasmedge-macro
 
       - name: Publish
-        working-directory: wasmedge-rust-sdk
         if: github.ref == 'refs/heads/main'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRIES_MACRO_TOKEN }}
@@ -44,7 +41,6 @@ jobs:
           cargo publish -p wasmedge-macro
 
       - name: Build API document
-        working-directory: wasmedge-rust-sdk
         run: |
           cargo doc -p wasmedge-macro --no-deps --target-dir=./target
 
@@ -54,5 +50,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
-          publish_dir: wasmedge-rust-sdk/target/doc
+          publish_dir: target/doc
           force_orphan: true

--- a/.github/workflows/release-wasmedge-sdk.yml
+++ b/.github/workflows/release-wasmedge-sdk.yml
@@ -1,10 +1,16 @@
-name: wasmedge-sdk-release
+name: Release wasmedge-sdk crate
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      wasmedge_version:
+        description: "Version of WasmEdge"
+        required: true
+        type: string
 
 jobs:
   release_wasmedge_sdk:
@@ -18,13 +24,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          path: wasmedge-rust-sdk
-
-      - name: Checkout WasmEdge Runtime
-        uses: actions/checkout@v3
-        with:
-          repository: WasmEdge/WasmEdge
-          path: WasmEdge
 
       - name: Set up build environment
         run: |
@@ -32,21 +31,15 @@ jobs:
           apt install -y software-properties-common libboost-all-dev ninja-build
           apt install -y llvm-15-dev liblld-15-dev
 
-      - name: Build WasmEdge with Release mode
-        working-directory: WasmEdge
+      - name: Install WasmEdge
         run: |
-          cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_PLUGIN_PROCESS=On .
-          cmake --build build
-          cmake --install build
+          curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- -v ${{ inputs.wasmedge_version }} -p /usr/local
           ldconfig
 
-      - name: Install Rust v1.68
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.68
+      - name: Install Rust-nightly
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: Dry run cargo publish
-        working-directory: wasmedge-rust-sdk
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRIES_SDK_TOKEN }}
         shell: bash
@@ -54,7 +47,6 @@ jobs:
           cargo publish --dry-run -p wasmedge-sdk
 
       - name: Publish
-        working-directory: wasmedge-rust-sdk
         if: github.ref == 'refs/heads/main'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRIES_SDK_TOKEN }}
@@ -64,7 +56,6 @@ jobs:
           cargo publish -p wasmedge-sdk
 
       - name: Build API document
-        working-directory: wasmedge-rust-sdk
         run: |
           RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc -p wasmedge-sdk --workspace --no-deps --features aot,wasi_crypto,wasi_nn,wasmedge_process,ffi --target-dir=./target
 
@@ -74,19 +65,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
-          publish_dir: wasmedge-rust-sdk/target/doc
+          publish_dir: target/doc
           force_orphan: true
-
-      # - name: Build Async API document
-      #   working-directory: wasmedge-rust-sdk
-      #   run: |
-      #     RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc -p wasmedge-sdk --workspace --no-deps --features aot,async,wasi_crypto,wasi_nn,wasmedge_process,ffi --target-dir=./target/async-wasmedge
-
-      # - name: Deploy Async API document
-      #   if: github.ref == 'refs/heads/main'
-      #   uses: peaceiris/actions-gh-pages@v3
-      #   with:
-      #     github_token: ${{ secrets.GITHUB_TOKEN }}
-      #     publish_branch: gh-pages
-      #     publish_dir: wasmedge-rust-sdk/target/async-wasmedge/doc
-      #     force_orphan: true

--- a/.github/workflows/release-wasmedge-sys.yml
+++ b/.github/workflows/release-wasmedge-sys.yml
@@ -1,10 +1,16 @@
-name: wasmedge-sys-release
+name: Release wasmedge-sys crate
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      wasmedge_version:
+        description: "Version of WasmEdge"
+        required: true
+        type: string
 
 jobs:
   release_wasmedge_sys:
@@ -18,13 +24,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          path: wasmedge-rust-sdk
-
-      - name: Checkout WasmEdge Runtime
-        uses: actions/checkout@v3
-        with:
-          repository: WasmEdge/WasmEdge
-          path: WasmEdge
 
       - name: Set up build environment
         run: |
@@ -32,21 +31,15 @@ jobs:
           apt install -y software-properties-common libboost-all-dev ninja-build
           apt install -y llvm-15-dev liblld-15-dev
 
-      - name: Build WasmEdge with Release mode
-        working-directory: WasmEdge
+      - name: Install WasmEdge
         run: |
-          cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_PLUGIN_PROCESS=On .
-          cmake --build build
-          cmake --install build
+          curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- -v ${{ inputs.wasmedge_version }} -p /usr/local
           ldconfig
 
-      - name: Install Rust v1.68
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.68
+      - name: Install Rust-nightly
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: Dry run cargo publish
-        working-directory: wasmedge-rust-sdk
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRIES_SYS_TOKEN }}
         shell: bash
@@ -54,7 +47,6 @@ jobs:
           cargo publish --dry-run -p wasmedge-sys
 
       - name: Publish
-        working-directory: wasmedge-rust-sdk
         if: github.ref == 'refs/heads/main'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRIES_SYS_TOKEN }}
@@ -64,7 +56,6 @@ jobs:
           cargo publish -p wasmedge-sys
 
       - name: Build API document
-        working-directory: wasmedge-rust-sdk
         run: |
           RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc -p wasmedge-sys --workspace --no-deps --features aot,wasi_crypto,wasi_nn,wasmedge_process,ffi --target-dir=./target
 
@@ -74,5 +65,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
-          publish_dir: wasmedge-rust-sdk/target/doc
+          publish_dir: target/doc
           force_orphan: true

--- a/.github/workflows/release-wasmedge-types.yml
+++ b/.github/workflows/release-wasmedge-types.yml
@@ -1,4 +1,4 @@
-name: wasmedge-types-release
+name: Release wasmedge-types crate
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -18,7 +18,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          path: wasmedge-rust-sdk
 
       - name: Install Rust v1.68
         uses: dtolnay/rust-toolchain@stable
@@ -26,7 +25,6 @@ jobs:
           toolchain: 1.68
 
       - name: Dry run cargo publish
-        working-directory: wasmedge-rust-sdk
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRIES_TYPES_TOKEN }}
         shell: bash
@@ -34,7 +32,6 @@ jobs:
           cargo publish --dry-run -p wasmedge-types
 
       - name: Publish
-        working-directory: wasmedge-rust-sdk
         if: github.ref == 'refs/heads/main'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRIES_TYPES_TOKEN }}
@@ -44,7 +41,6 @@ jobs:
           cargo publish -p wasmedge-types
 
       - name: Build API document
-        working-directory: wasmedge-rust-sdk
         run: |
           cargo doc -p wasmedge-types --no-deps --target-dir=./target
 
@@ -54,5 +50,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
-          publish_dir: wasmedge-rust-sdk/target/doc
+          publish_dir: target/doc
           force_orphan: true

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -8,12 +8,12 @@ on:
   push:
     paths-ignore:
       - "**/*.md"
+      - ".github/workflows/ci-build.yml"
 
   pull_request:
     paths-ignore:
       - "**/*.md"
-
-  workflow_dispatch:
+      - ".github/workflows/ci-build.yml"
 
 jobs:
   build_ubuntu_2204:

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -4,7 +4,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-on: workflow_dispatch
+on:
+  push:
+    paths-ignore:
+      - "**/*.md"
+
+  pull_request:
+    paths-ignore:
+      - "**/*.md"
+
+  workflow_dispatch:
 
 jobs:
   build_ubuntu_2204:
@@ -103,4 +112,37 @@ jobs:
           export CC=clang
           export CXX=clang++
           export DYLD_LIBRARY_PATH=$HOME/.wasmedge/lib
+          cargo test -p wasmedge-sdk --all --examples --features standalone
+
+  build_fedora:
+    name: Fedora latest
+    runs-on: Fedora-latest
+    strategy:
+      matrix:
+        rust: [1.71, 1.70.0, 1.69]
+    container:
+      image: fedora:latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up build environment
+        run: |
+          apt update
+          apt install -y software-properties-common libboost-all-dev ninja-build
+          apt install -y llvm-15-dev liblld-15-dev
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.rust }}
+
+      - name: Run in the standalone mode
+        run: |
+          export LLVM_DIR="/usr/local/opt/llvm/lib/cmake"
+          export CC=clang
+          export CXX=clang++
+          export LD_LIBRARY_PATH=$HOME/.wasmedge/lib
           cargo test -p wasmedge-sdk --all --examples --features standalone

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -116,7 +116,7 @@ jobs:
 
   build_fedora:
     name: Fedora latest
-    runs-on: Fedora-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         rust: [1.71, 1.70.0, 1.69]

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -130,9 +130,8 @@ jobs:
 
       - name: Set up build environment
         run: |
-          apt update
-          apt install -y software-properties-common libboost-all-dev ninja-build
-          apt install -y llvm-15-dev liblld-15-dev
+          dnf update -y
+          dnf install -y cmake ninja-build boost llvm llvm-devel lld-devel clang git file rpm-build dpkg-dev spdlog-devel
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -1,4 +1,4 @@
-name: rust-standalone-test
+name: Test standalone mode
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/README.md
+++ b/README.md
@@ -55,7 +55,12 @@ The following architectures are supported for automatic downloads:
 
 This crate uses `rust-bindgen` during the build process. If you would like to use an external `rust-bindgen` you can set the `WASMEDGE_RUST_BINDGEN_PATH` environment variable to the `bindgen` executable path. This is particularly useful in systems like Alpine Linux (see [rust-lang/rust-bindgen#2360](https://github.com/rust-lang/rust-bindgen/issues/2360#issuecomment-1595869379), [rust-lang/rust-bindgen#2333](https://github.com/rust-lang/rust-bindgen/issues/2333)).
 
-**Notice:** The minimum supported Rust version is 1.68.
+**Notice:** The minimum supported Rust version is 1.69.
+
+## API Reference
+
+- [API Reference](https://docs.rs/crate/wasmedge-sdk/)
+- [Async API Reference](https://wasmedge.github.io/wasmedge-rust-sdk/wasmedge_sdk/)
 
 ## Examples
 

--- a/crates/wasmedge-sys/README.md
+++ b/crates/wasmedge-sys/README.md
@@ -10,6 +10,11 @@ For developers, it is recommended that the APIs in `wasmedge-sys` are used to co
 
 This crate depends on the WasmEdge C API. In linux/macOS the crate can download the API at build time by enabling the `standalone` feature. Otherwise the API needs to be installed in your system first. Please refer to [Get Started](https://github.com/WasmEdge/wasmedge-rust-sdk#get-started) for more information.
 
+## API Reference
+
+* [wasmedge-sys API Reference](https://wasmedge.github.io/wasmedge-rust-sdk/wasmedge_sys/)
+* [wasmedge-sys Async API Reference](https://second-state.github.io/wasmedge-async-rust-sdk/wasmedge_sys/)
+
 ## See also
 
 * [WasmEdge Runtime Official Website](https://wasmedge.org/)

--- a/crates/wasmedge-sys/src/lib.rs
+++ b/crates/wasmedge-sys/src/lib.rs
@@ -35,9 +35,11 @@
 //!   | 0.3.0         | 0.10.1        | 0.8           | 0.2           | -             | -         |
 //!   | 0.1.0         | 0.10.0        | 0.7           | 0.1           | -             | -         |
 //!
+//! ## API Reference
 //!
+//! * [wasmedge-sys API Reference](https://docs.rs/crate/wasmedge-sys/)
+//! * [wasmedge-sys Async API Reference](https://wasmedge.github.io/wasmedge-rust-sdk/wasmedge_sys/)
 //!
-
 //! ## See also
 //!
 //! * [WasmEdge Runtime Official Website](https://wasmedge.org/)

--- a/crates/wasmedge-types/src/error.rs
+++ b/crates/wasmedge-types/src/error.rs
@@ -478,6 +478,7 @@ pub enum CoreExecutionError {
     ExpectSharedMemory,
 }
 
+/// The error type for the host function definition.
 #[derive(Error, Clone, Debug, PartialEq, Eq)]
 pub enum HostFuncError {
     #[error("User error: {0}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,12 @@
 //!
 //! This crate uses `rust-bindgen` during the build process. If you would like to use an external `rust-bindgen` you can set the `WASMEDGE_RUST_BINDGEN_PATH` environment variable to the `bindgen` executable path. This is particularly useful in systems like Alpine Linux (see [rust-lang/rust-bindgen#2360](https://github.com/rust-lang/rust-bindgen/issues/2360#issuecomment-1595869379), [rust-lang/rust-bindgen#2333](https://github.com/rust-lang/rust-bindgen/issues/2333)).
 //!
-//! **Notice:** The minimum supported Rust version is 1.68.
+//! **Notice:** The minimum supported Rust version is 1.69.
+//!
+//! ## API Reference
+//!
+//! - [API Reference](https://docs.rs/crate/wasmedge-sdk/)
+//! - [Async API Reference](https://wasmedge.github.io/wasmedge-rust-sdk/wasmedge_sdk/)
 //!
 //! ## Examples
 //!


### PR DESCRIPTION
In this PR, the following ci workflows are updated:

- `publish-async-api-docs`: remove the checkout path
- `ci-build`: add ignored paths
- `standalone`: add `build_fedora` job

In addition, add `API Reference` sections in `README` and rustdoc.