### PR TITLE
[Feat] Implement new API `PluginManager::nn_preload`

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04]
-        rust: [1.71, 1.70.0, 1.69]
+        rust: [1.72, 1.71, 1.70.0]
     container:
       image: wasmedge/wasmedge:ubuntu-build-clang
 
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.71, 1.70.0, 1.69]
+        rust: [1.72, 1.71, 1.70.0]
     container:
       image: fedora:latest
 
@@ -167,7 +167,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-11, macos-12]
-        rust: [1.71, 1.70.0, 1.69]
+        rust: [1.72, 1.71, 1.70.0]
 
     steps:
       - name: Checkout sources
@@ -222,7 +222,7 @@ jobs:
     runs-on: windows-2022
     strategy:
       matrix:
-        rust: [1.71, 1.70.0, 1.69]
+        rust: [1.72, 1.71, 1.70.0]
     env:
       WASMEDGE_DIR: ${{ github.workspace }}\WasmEdge
       WASMEDGE_BUILD_DIR: ${{ github.workspace }}\WasmEdge\build

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        rust: [1.71, 1.70.0, 1.69]
+        rust: [1.72, 1.71, 1.70.0]
 
     steps:
       - name: Checkout WasmEdge Rust SDK
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        rust: [1.71, 1.70.0, 1.69]
+        rust: [1.72, 1.71, 1.70.0]
 
     steps:
       - name: Checkout WasmEdge Rust SDK
@@ -90,7 +90,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-11, macos-12]
-        rust: [1.71, 1.70.0, 1.69]
+        rust: [1.72, 1.71, 1.70.0]
 
     steps:
       - name: Checkout sources
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.71, 1.70.0, 1.69]
+        rust: [1.72, 1.71, 1.70.0]
     container:
       image: fedora:latest
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "wasmedge-sdk"
 readme = "README.md"
 repository = "https://github.com/WasmEdge/wasmedge-rust-sdk"
-version = "0.12.1"
+version = "0.12.2"
 
 [dependencies]
 anyhow = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "wasmedge-sdk"
 readme = "README.md"
 repository = "https://github.com/WasmEdge/wasmedge-rust-sdk"
-version = "0.12.2"
+version = "0.12.2-dev"
 
 [dependencies]
 anyhow = "1.0"

--- a/crates/wasmedge-sys/Cargo.toml
+++ b/crates/wasmedge-sys/Cargo.toml
@@ -10,7 +10,7 @@ links = "wasmedge"
 name = "wasmedge-sys"
 readme = "README.md"
 repository = "https://github.com/WasmEdge/wasmedge-rust-sdk"
-version = "0.17.1"
+version = "0.17.2"
 
 [dependencies]
 fiber-for-wasmedge = { version = "8.0.1", optional = true }

--- a/crates/wasmedge-sys/src/plugin.rs
+++ b/crates/wasmedge-sys/src/plugin.rs
@@ -57,7 +57,7 @@ impl PluginManager {
             .collect();
         let c_strs: Vec<*const i8> = c_args.iter().map(|x| x.as_ptr()).collect();
         let len = c_strs.len() as u32;
-        unsafe { ffi::WasmEdge_ModuleInstanceInitWASINN(c_strs.as_ptr(), len) }
+        unsafe { ffi::WasmEdge_PluginInitWASINN(c_strs.as_ptr(), len) }
     }
 
     /// Returns the count of loaded plugins.

--- a/crates/wasmedge-sys/src/plugin.rs
+++ b/crates/wasmedge-sys/src/plugin.rs
@@ -7,7 +7,10 @@ use crate::{
     utils, AsImport, Instance, WasmEdgeResult,
 };
 use parking_lot::Mutex;
-use std::{ffi::CString, os::raw::c_void, sync::Arc};
+use std::{
+    ffi::{c_void, CString},
+    sync::Arc,
+};
 use wasmedge_types::error::{InstanceError, PluginError, WasmEdgeError};
 
 /// Defines the APIs for loading plugins and check the basic information of the loaded plugins.
@@ -43,6 +46,18 @@ impl PluginManager {
         unsafe { ffi::WasmEdge_PluginLoadFromPath(c_path.as_ptr()) }
 
         Ok(())
+    }
+
+    #[cfg(feature = "wasi_nn")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "wasi_nn")))]
+    pub fn nn_preload(preloads: Vec<&str>) {
+        let c_args: Vec<CString> = preloads
+            .iter()
+            .map(|&x| std::ffi::CString::new(x).unwrap())
+            .collect();
+        let c_strs: Vec<*const i8> = c_args.iter().map(|x| x.as_ptr()).collect();
+        let len = c_strs.len() as u32;
+        unsafe { ffi::WasmEdge_ModuleInstanceInitWASINN(c_strs.as_ptr(), len) }
     }
 
     /// Returns the count of loaded plugins.

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -46,6 +46,12 @@ impl PluginManager {
         }
     }
 
+    #[cfg(feature = "wasi_nn")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "wasi_nn")))]
+    pub fn nn_preload(preloads: Vec<&str>) {
+        sys::plugin::PluginManager::nn_preload(preloads);
+    }
+
     /// Returns the count of loaded plugins.
     pub fn count() -> u32 {
         sys::plugin::PluginManager::count()


### PR DESCRIPTION
In this PR, add new API `nn_repload` for `PluginManager` to support new C-API `WasmEdge_PluginInitWASINN`.