### PR TITLE
[Refactor] Disable `Plugin::nn_preload`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "wasmedge-sdk"
 readme = "README.md"
 repository = "https://github.com/WasmEdge/wasmedge-rust-sdk"
-version = "0.12.2-dev"
+version = "0.12.2"
 
 [dependencies]
 anyhow = "1.0"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This crate depends on the WasmEdge C API. In linux/macOS the crate can download 
 
   | wasmedge-sdk  | WasmEdge lib  | wasmedge-sys  | wasmedge-types| wasmedge-macro| async-wasi|
   | :-----------: | :-----------: | :-----------: | :-----------: | :-----------: | :-------: |
+  | 0.12.2        | 0.13.4        | 0.17.2        | 0.4.4         | 0.6.1         | 0.1.0     |
   | 0.12.1        | 0.13.4        | 0.17.1        | 0.4.4         | 0.6.1         | 0.1.0     |
   | 0.12.0        | 0.13.4        | 0.17.0        | 0.4.4         | 0.6.1         | 0.1.0     |
   | 0.11.2        | 0.13.3        | 0.16.2        | 0.4.3         | 0.6.1         | 0.1.0     |
@@ -57,7 +58,7 @@ The following architectures are supported for automatic downloads:
 
 This crate uses `rust-bindgen` during the build process. If you would like to use an external `rust-bindgen` you can set the `WASMEDGE_RUST_BINDGEN_PATH` environment variable to the `bindgen` executable path. This is particularly useful in systems like Alpine Linux (see [rust-lang/rust-bindgen#2360](https://github.com/rust-lang/rust-bindgen/issues/2360#issuecomment-1595869379), [rust-lang/rust-bindgen#2333](https://github.com/rust-lang/rust-bindgen/issues/2333)).
 
-**Notice:** The minimum supported Rust version is 1.69.
+**Notice:** The minimum supported Rust version is 1.70.
 
 ## API Reference
 

--- a/crates/wasmedge-sys/README.md
+++ b/crates/wasmedge-sys/README.md
@@ -4,7 +4,7 @@ The [wasmedge-sys](https://crates.io/crates/wasmedge-sys) crate defines a group 
 
 For developers, it is recommended that the APIs in `wasmedge-sys` are used to construct high-level libraries, while `wasmedge-sdk` is for building up business applications.
 
-* Notice that [wasmedge-sys](https://crates.io/crates/wasmedge-sys) requires **Rust v1.69 or above** in the **stable** channel.
+* Notice that [wasmedge-sys](https://crates.io/crates/wasmedge-sys) requires **Rust v1.70 or above** in the **stable** channel.
 
 ## Build
 

--- a/crates/wasmedge-sys/src/lib.rs
+++ b/crates/wasmedge-sys/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! For developers, it is strongly recommended that the APIs in `wasmedge-sys` are used to construct high-level libraries, while `wasmedge-sdk` is for building up business applications.
 //!
-//! * Notice that [wasmedge-sys](https://crates.io/crates/wasmedge-sys) requires **Rust v1.69 or above** in the **stable** channel.
+//! * Notice that [wasmedge-sys](https://crates.io/crates/wasmedge-sys) requires **Rust v1.70 or above** in the **stable** channel.
 //!
 
 //! ## Build
@@ -19,6 +19,7 @@
 //!
 //!   | wasmedge-sdk  | WasmEdge lib  | wasmedge-sys  | wasmedge-types| wasmedge-macro| async-wasi|
 //!   | :-----------: | :-----------: | :-----------: | :-----------: | :-----------: | :-------: |
+//!   | 0.12.2        | 0.13.4        | 0.17.2        | 0.4.4         | 0.6.1         | 0.1.0     |
 //!   | 0.12.1        | 0.13.4        | 0.17.1        | 0.4.4         | 0.6.1         | 0.1.0     |
 //!   | 0.12.0        | 0.13.4        | 0.17.0        | 0.4.4         | 0.6.1         | 0.1.0     |
 //!   | 0.11.2        | 0.13.3        | 0.16.2        | 0.4.3         | 0.6.1         | 0.1.0     |

--- a/crates/wasmedge-sys/src/plugin.rs
+++ b/crates/wasmedge-sys/src/plugin.rs
@@ -48,17 +48,17 @@ impl PluginManager {
         Ok(())
     }
 
-    #[cfg(feature = "wasi_nn")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "wasi_nn")))]
-    pub fn nn_preload(preloads: Vec<&str>) {
-        let c_args: Vec<CString> = preloads
-            .iter()
-            .map(|&x| std::ffi::CString::new(x).unwrap())
-            .collect();
-        let c_strs: Vec<*const i8> = c_args.iter().map(|x| x.as_ptr()).collect();
-        let len = c_strs.len() as u32;
-        unsafe { ffi::WasmEdge_PluginInitWASINN(c_strs.as_ptr(), len) }
-    }
+    // #[cfg(feature = "wasi_nn")]
+    // #[cfg_attr(docsrs, doc(cfg(feature = "wasi_nn")))]
+    // pub fn nn_preload(preloads: Vec<&str>) {
+    //     let c_args: Vec<CString> = preloads
+    //         .iter()
+    //         .map(|&x| std::ffi::CString::new(x).unwrap())
+    //         .collect();
+    //     let c_strs: Vec<*const i8> = c_args.iter().map(|x| x.as_ptr()).collect();
+    //     let len = c_strs.len() as u32;
+    //     unsafe { ffi::WasmEdge_PluginInitWASINN(c_strs.as_ptr(), len) }
+    // }
 
     /// Returns the count of loaded plugins.
     pub fn count() -> u32 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@
 //!
 //! | wasmedge-sdk  | WasmEdge lib  | wasmedge-sys  | wasmedge-types| wasmedge-macro| async-wasi|
 //! | :-----------: | :-----------: | :-----------: | :-----------: | :-----------: | :-------: |
+//! | 0.12.2        | 0.13.4        | 0.17.2        | 0.4.4         | 0.6.1         | 0.1.0     |
 //! | 0.12.1        | 0.13.4        | 0.17.1        | 0.4.4         | 0.6.1         | 0.1.0     |
 //! | 0.12.0        | 0.13.4        | 0.17.0        | 0.4.4         | 0.6.1         | 0.1.0     |
 //! | 0.11.2        | 0.13.3        | 0.16.2        | 0.4.3         | 0.6.1         | 0.1.0     |
@@ -66,7 +67,7 @@
 //!
 //! This crate uses `rust-bindgen` during the build process. If you would like to use an external `rust-bindgen` you can set the `WASMEDGE_RUST_BINDGEN_PATH` environment variable to the `bindgen` executable path. This is particularly useful in systems like Alpine Linux (see [rust-lang/rust-bindgen#2360](https://github.com/rust-lang/rust-bindgen/issues/2360#issuecomment-1595869379), [rust-lang/rust-bindgen#2333](https://github.com/rust-lang/rust-bindgen/issues/2333)).
 //!
-//! **Notice:** The minimum supported Rust version is 1.69.
+//! **Notice:** The minimum supported Rust version is 1.70.
 //!
 //! ## API Reference
 //!

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -46,11 +46,11 @@ impl PluginManager {
         }
     }
 
-    #[cfg(feature = "wasi_nn")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "wasi_nn")))]
-    pub fn nn_preload(preloads: Vec<&str>) {
-        sys::plugin::PluginManager::nn_preload(preloads);
-    }
+    // #[cfg(feature = "wasi_nn")]
+    // #[cfg_attr(docsrs, doc(cfg(feature = "wasi_nn")))]
+    // pub fn nn_preload(preloads: Vec<&str>) {
+    //     sys::plugin::PluginManager::nn_preload(preloads);
+    // }
 
     /// Returns the count of loaded plugins.
     pub fn count() -> u32 {


### PR DESCRIPTION
In this PR, temporarily disable `Plugin::nn_preload` for publishing a quick release. 