### PR TITLE
[Feat] Enable `PluginManager::nn_preload`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "wasmedge-sdk"
 readme = "README.md"
 repository = "https://github.com/WasmEdge/wasmedge-rust-sdk"
-version = "0.12.2"
+version = "0.12.3-dev"
 
 [dependencies]
 anyhow = "1.0"

--- a/crates/wasmedge-sys/Cargo.toml
+++ b/crates/wasmedge-sys/Cargo.toml
@@ -10,7 +10,7 @@ links = "wasmedge"
 name = "wasmedge-sys"
 readme = "README.md"
 repository = "https://github.com/WasmEdge/wasmedge-rust-sdk"
-version = "0.17.2"
+version = "0.17.3"
 
 [dependencies]
 fiber-for-wasmedge = { version = "8.0.1", optional = true }

--- a/crates/wasmedge-sys/src/plugin.rs
+++ b/crates/wasmedge-sys/src/plugin.rs
@@ -48,17 +48,17 @@ impl PluginManager {
         Ok(())
     }
 
-    // #[cfg(feature = "wasi_nn")]
-    // #[cfg_attr(docsrs, doc(cfg(feature = "wasi_nn")))]
-    // pub fn nn_preload(preloads: Vec<&str>) {
-    //     let c_args: Vec<CString> = preloads
-    //         .iter()
-    //         .map(|&x| std::ffi::CString::new(x).unwrap())
-    //         .collect();
-    //     let c_strs: Vec<*const i8> = c_args.iter().map(|x| x.as_ptr()).collect();
-    //     let len = c_strs.len() as u32;
-    //     unsafe { ffi::WasmEdge_PluginInitWASINN(c_strs.as_ptr(), len) }
-    // }
+    #[cfg(feature = "wasi_nn")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "wasi_nn")))]
+    pub fn nn_preload(preloads: Vec<&str>) {
+        let c_args: Vec<CString> = preloads
+            .iter()
+            .map(|&x| std::ffi::CString::new(x).unwrap())
+            .collect();
+        let c_strs: Vec<*const i8> = c_args.iter().map(|x| x.as_ptr()).collect();
+        let len = c_strs.len() as u32;
+        unsafe { ffi::WasmEdge_PluginInitWASINN(c_strs.as_ptr(), len) }
+    }
 
     /// Returns the count of loaded plugins.
     pub fn count() -> u32 {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -46,11 +46,11 @@ impl PluginManager {
         }
     }
 
-    // #[cfg(feature = "wasi_nn")]
-    // #[cfg_attr(docsrs, doc(cfg(feature = "wasi_nn")))]
-    // pub fn nn_preload(preloads: Vec<&str>) {
-    //     sys::plugin::PluginManager::nn_preload(preloads);
-    // }
+    #[cfg(feature = "wasi_nn")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "wasi_nn")))]
+    pub fn nn_preload(preloads: Vec<&str>) {
+        sys::plugin::PluginManager::nn_preload(preloads);
+    }
 
     /// Returns the count of loaded plugins.
     pub fn count() -> u32 {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -28,6 +28,23 @@ pub struct NNPreload {
 }
 #[cfg(feature = "wasi_nn")]
 #[cfg_attr(docsrs, doc(cfg(feature = "wasi_nn")))]
+impl NNPreload {
+    pub fn new(
+        alias: impl AsRef<str>,
+        backend: NNBackend,
+        target: ExecutionTarget,
+        path: impl AsRef<std::path::Path>,
+    ) -> Self {
+        Self {
+            alias: alias.as_ref().to_owned(),
+            backend,
+            target,
+            path: path.as_ref().to_owned(),
+        }
+    }
+}
+#[cfg(feature = "wasi_nn")]
+#[cfg_attr(docsrs, doc(cfg(feature = "wasi_nn")))]
 impl std::fmt::Display for NNPreload {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -13,6 +13,78 @@ pub mod ffi {
     };
 }
 
+#[cfg(feature = "wasi_nn")]
+#[cfg_attr(docsrs, doc(cfg(feature = "wasi_nn")))]
+#[derive(Debug, Clone)]
+pub struct NNPreload {
+    /// The alias of the model in the WASI-NN environment.
+    pub alias: String,
+    /// The inference backend.
+    pub backend: Backend,
+    /// The execution target, on which the inference runs.
+    pub target: ExecutionTarget,
+    /// The path to the model file. Note that the path is the guest path instead of the host path.
+    pub path: Path,
+}
+#[cfg(feature = "wasi_nn")]
+#[cfg_attr(docsrs, doc(cfg(feature = "wasi_nn")))]
+impl NNPreload {
+    fn to_string(&self) -> String {
+        format!(
+            "{alias}:{backend}:{target}:{path}",
+            alias = self.alias,
+            backend = self.backend.to_string(),
+            target = self.target.to_string(),
+            path = self.path.to_string_lossy().into_owned()
+        )
+    }
+}
+
+#[cfg(feature = "wasi_nn")]
+#[cfg_attr(docsrs, doc(cfg(feature = "wasi_nn")))]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[allow(non_camel_case_types)]
+pub enum NNBackend {
+    PyTorch,
+    TensorFlowLite,
+    OpenVINO,
+    GGML,
+}
+#[cfg(feature = "wasi_nn")]
+#[cfg_attr(docsrs, doc(cfg(feature = "wasi_nn")))]
+impl NNBackend {
+    fn to_string(&self) -> String {
+        match self {
+            NNBackend::PyTorch => "PyTorch".to_string(),
+            NNBackend::TensorFlowLite => "TensorFlowLite".to_string(),
+            NNBackend::OpenVINO => "OpenVINO".to_string(),
+            NNBackend::GGML => "GGML".to_string(),
+        }
+    }
+}
+
+/// Define where the graph should be executed.
+#[cfg(feature = "wasi_nn")]
+#[cfg_attr(docsrs, doc(cfg(feature = "wasi_nn")))]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[allow(non_camel_case_types)]
+pub enum ExecutionTarget {
+    CPU,
+    GPU,
+    TPU,
+}
+#[cfg(feature = "wasi_nn")]
+#[cfg_attr(docsrs, doc(cfg(feature = "wasi_nn")))]
+impl ExecutionTarget {
+    fn to_string(&self) -> String {
+        match self {
+            ExecutionTarget::CPU => "CPU".to_string(),
+            ExecutionTarget::GPU => "GPU".to_string(),
+            ExecutionTarget::TPU => "TPU".to_string(),
+        }
+    }
+}
+
 /// Defines the API to manage plugins.
 #[derive(Debug)]
 pub struct PluginManager {}
@@ -48,8 +120,13 @@ impl PluginManager {
 
     #[cfg(feature = "wasi_nn")]
     #[cfg_attr(docsrs, doc(cfg(feature = "wasi_nn")))]
-    pub fn nn_preload(preloads: Vec<&str>) {
-        sys::plugin::PluginManager::nn_preload(preloads);
+    pub fn nn_preload(preloads: Vec<NNPreload>) {
+        let mut nn_preloads = Vec::new();
+        for preload in preloads {
+            nn_preloads.push(preload.to_string());
+        }
+
+        sys::plugin::PluginManager::nn_preload(nn_preloads);
     }
 
     /// Returns the count of loaded plugins.

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -15,26 +15,27 @@ pub mod ffi {
 
 #[cfg(feature = "wasi_nn")]
 #[cfg_attr(docsrs, doc(cfg(feature = "wasi_nn")))]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct NNPreload {
     /// The alias of the model in the WASI-NN environment.
     pub alias: String,
     /// The inference backend.
-    pub backend: Backend,
+    pub backend: NNBackend,
     /// The execution target, on which the inference runs.
     pub target: ExecutionTarget,
     /// The path to the model file. Note that the path is the guest path instead of the host path.
-    pub path: Path,
+    pub path: std::path::PathBuf,
 }
 #[cfg(feature = "wasi_nn")]
 #[cfg_attr(docsrs, doc(cfg(feature = "wasi_nn")))]
-impl NNPreload {
-    fn to_string(&self) -> String {
-        format!(
+impl std::fmt::Display for NNPreload {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
             "{alias}:{backend}:{target}:{path}",
             alias = self.alias,
-            backend = self.backend.to_string(),
-            target = self.target.to_string(),
+            backend = self.backend,
+            target = self.target,
             path = self.path.to_string_lossy().into_owned()
         )
     }
@@ -52,13 +53,13 @@ pub enum NNBackend {
 }
 #[cfg(feature = "wasi_nn")]
 #[cfg_attr(docsrs, doc(cfg(feature = "wasi_nn")))]
-impl NNBackend {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for NNBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            NNBackend::PyTorch => "PyTorch".to_string(),
-            NNBackend::TensorFlowLite => "TensorFlowLite".to_string(),
-            NNBackend::OpenVINO => "OpenVINO".to_string(),
-            NNBackend::GGML => "GGML".to_string(),
+            NNBackend::PyTorch => write!(f, "PyTorch"),
+            NNBackend::TensorFlowLite => write!(f, "TensorFlowLite"),
+            NNBackend::OpenVINO => write!(f, "OpenVINO"),
+            NNBackend::GGML => write!(f, "GGML"),
         }
     }
 }
@@ -75,12 +76,12 @@ pub enum ExecutionTarget {
 }
 #[cfg(feature = "wasi_nn")]
 #[cfg_attr(docsrs, doc(cfg(feature = "wasi_nn")))]
-impl ExecutionTarget {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for ExecutionTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ExecutionTarget::CPU => "CPU".to_string(),
-            ExecutionTarget::GPU => "GPU".to_string(),
-            ExecutionTarget::TPU => "TPU".to_string(),
+            ExecutionTarget::CPU => write!(f, "CPU"),
+            ExecutionTarget::GPU => write!(f, "GPU"),
+            ExecutionTarget::TPU => write!(f, "TPU"),
         }
     }
 }
@@ -126,7 +127,9 @@ impl PluginManager {
             nn_preloads.push(preload.to_string());
         }
 
-        sys::plugin::PluginManager::nn_preload(nn_preloads);
+        let nn_preloads_str: Vec<&str> = nn_preloads.iter().map(|s| s.as_str()).collect();
+
+        sys::plugin::PluginManager::nn_preload(nn_preloads_str);
     }
 
     /// Returns the count of loaded plugins.


### PR DESCRIPTION
In this PR, the `PluginManager::nn_preload` API in `wasmedge-sdk` is enabled. In addition, improve the original argument design.

The new design has been verified by the [ggml-llama-via-wasinn](https://github.com/second-state/wasmedge-rustsdk-examples/tree/dev/ggml-llama-via-wasinn) example.