### PR TITLE
[refactor] Introduce `WasmEdge_FunctionInstanceGetData` to drop host data

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -166,7 +166,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-11, macos-12]
+        os: [macos-12, macos-13]
         rust: [1.73, 1.72, 1.71]
 
     steps:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04]
-        rust: [1.72, 1.71, 1.70.0]
+        rust: [1.73, 1.72, 1.71]
     container:
       image: wasmedge/wasmedge:ubuntu-build-clang
 
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.72, 1.71, 1.70.0]
+        rust: [1.73, 1.72, 1.71]
     container:
       image: fedora:latest
 
@@ -167,7 +167,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-11, macos-12]
-        rust: [1.72, 1.71, 1.70.0]
+        rust: [1.73, 1.72, 1.71]
 
     steps:
       - name: Checkout sources
@@ -222,7 +222,7 @@ jobs:
     runs-on: windows-2022
     strategy:
       matrix:
-        rust: [1.72, 1.71, 1.70.0]
+        rust: [1.73, 1.72, 1.71]
     env:
       WASMEDGE_DIR: ${{ github.workspace }}\WasmEdge
       WASMEDGE_BUILD_DIR: ${{ github.workspace }}\WasmEdge\build

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        rust: [1.72, 1.71, 1.70.0]
+        rust: [1.73, 1.72, 1.71]
 
     steps:
       - name: Checkout WasmEdge Rust SDK
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        rust: [1.72, 1.71, 1.70.0]
+        rust: [1.73, 1.72, 1.71]
 
     steps:
       - name: Checkout WasmEdge Rust SDK
@@ -90,7 +90,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-11, macos-12]
-        rust: [1.72, 1.71, 1.70.0]
+        rust: [1.73, 1.72, 1.71]
 
     steps:
       - name: Checkout sources
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.72, 1.71, 1.70.0]
+        rust: [1.73, 1.72, 1.71]
     container:
       image: fedora:latest
 

--- a/.github/workflows/standalone.yml
+++ b/.github/workflows/standalone.yml
@@ -89,7 +89,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-11, macos-12]
+        os: [macos-12, macos-13]
         rust: [1.73, 1.72, 1.71]
 
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "wasmedge-sdk"
 readme = "README.md"
 repository = "https://github.com/WasmEdge/wasmedge-rust-sdk"
-version = "0.12.3-dev"
+version = "0.13.0"
 
 [dependencies]
 anyhow = "1.0"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This crate depends on the WasmEdge C API. In linux/macOS the crate can download 
 
   | wasmedge-sdk  | WasmEdge lib  | wasmedge-sys  | wasmedge-types| wasmedge-macro| async-wasi|
   | :-----------: | :-----------: | :-----------: | :-----------: | :-----------: | :-------: |
+  | 0.13.0        | 0.13.5        | 0.17.3        | 0.4.4         | 0.6.1         | 0.1.0     |
   | 0.12.2        | 0.13.4        | 0.17.2        | 0.4.4         | 0.6.1         | 0.1.0     |
   | 0.12.1        | 0.13.4        | 0.17.1        | 0.4.4         | 0.6.1         | 0.1.0     |
   | 0.12.0        | 0.13.4        | 0.17.0        | 0.4.4         | 0.6.1         | 0.1.0     |
@@ -58,7 +59,7 @@ The following architectures are supported for automatic downloads:
 
 This crate uses `rust-bindgen` during the build process. If you would like to use an external `rust-bindgen` you can set the `WASMEDGE_RUST_BINDGEN_PATH` environment variable to the `bindgen` executable path. This is particularly useful in systems like Alpine Linux (see [rust-lang/rust-bindgen#2360](https://github.com/rust-lang/rust-bindgen/issues/2360#issuecomment-1595869379), [rust-lang/rust-bindgen#2333](https://github.com/rust-lang/rust-bindgen/issues/2333)).
 
-**Notice:** The minimum supported Rust version is 1.70.
+**Notice:** The minimum supported Rust version is 1.71.
 
 ## API Reference
 

--- a/crates/wasmedge-sys/Cargo.toml
+++ b/crates/wasmedge-sys/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/WasmEdge/wasmedge-rust-sdk"
 version = "0.17.3"
 
 [dependencies]
-fiber-for-wasmedge = { version = "8.0.1", optional = true }
+fiber-for-wasmedge = { version = "14.0.4", optional = true }
 libc = "0.2.94"
 paste = "1.0.5"
 scoped-tls = "1"
@@ -32,7 +32,7 @@ async-wasi = { workspace = true, optional = true }
 setjmp = "0.1"
 
 [build-dependencies]
-bindgen = { version = "0.65", default-features = false, features = ["runtime"] }
+bindgen = { version = "0.69", default-features = false, features = ["runtime"] }
 cmake = "0.1"
 reqwest = { version = "0.11", default-features = false, features = [
     "blocking",

--- a/crates/wasmedge-sys/build.rs
+++ b/crates/wasmedge-sys/build.rs
@@ -136,7 +136,7 @@ fn main() {
             .clang_arg(format!("-I{inc_dir}"))
             .prepend_enum_name(false) // The API already prepends the name.
             .dynamic_link_require_all(true)
-            .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+            .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
             .generate()
             .expect("failed to generate bindings")
             .write_to_file(out_file)

--- a/crates/wasmedge-sys/src/instance/function.rs
+++ b/crates/wasmedge-sys/src/instance/function.rs
@@ -496,7 +496,6 @@ impl Function {
 }
 impl Drop for Function {
     fn drop(&mut self) {
-        dbg!("func registered: {}", self.registered);
         if !self.registered && Arc::strong_count(&self.inner) == 1 {
             // remove the real_func from HOST_FUNCS
             let footprint = self.inner.lock().0 as usize;

--- a/crates/wasmedge-sys/src/instance/function.rs
+++ b/crates/wasmedge-sys/src/instance/function.rs
@@ -495,6 +495,7 @@ impl Function {
     }
 }
 impl Drop for Function {
+    #[allow(clippy::from_raw_with_void_ptr)]
     fn drop(&mut self) {
         if !self.registered && Arc::strong_count(&self.inner) == 1 {
             // remove the real_func from HOST_FUNCS

--- a/crates/wasmedge-sys/src/instance/function.rs
+++ b/crates/wasmedge-sys/src/instance/function.rs
@@ -512,7 +512,14 @@ impl Drop for Function {
 
             // delete the function instance
             if !self.inner.lock().0.is_null() {
-                unsafe { ffi::WasmEdge_FunctionInstanceDelete(self.inner.lock().0) };
+                unsafe {
+                    // drop host data
+                    let _ =
+                        Box::from_raw(ffi::WasmEdge_FunctionInstanceGetData(self.inner.lock().0)
+                            as *mut c_void);
+
+                    ffi::WasmEdge_FunctionInstanceDelete(self.inner.lock().0)
+                };
             }
         }
     }

--- a/crates/wasmedge-sys/src/instance/module.rs
+++ b/crates/wasmedge-sys/src/instance/module.rs
@@ -393,6 +393,7 @@ pub struct ImportModule<T: ?Sized + Send + Sync + Clone> {
     data: Option<Box<T>>,
 }
 impl<T: ?Sized + Send + Sync + Clone> Drop for ImportModule<T> {
+    #[allow(clippy::from_raw_with_void_ptr)]
     fn drop(&mut self) {
         if !self.registered && Arc::strong_count(&self.inner) == 1 && !self.inner.0.is_null() {
             // cleanup the stuff belonging to each host function before really dropping the host function

--- a/crates/wasmedge-sys/src/lib.rs
+++ b/crates/wasmedge-sys/src/lib.rs
@@ -142,7 +142,7 @@ pub(crate) type BoxedFn = Box<
 >;
 
 lazy_static! {
-    pub static ref HOST_FUNCS: RwLock<HashMap<usize, Arc<Mutex<BoxedFn>>>> =
+    pub(crate) static ref HOST_FUNCS: RwLock<HashMap<usize, Arc<Mutex<BoxedFn>>>> =
         RwLock::new(HashMap::new());
 }
 
@@ -165,7 +165,8 @@ lazy_static! {
 
 // Stores the mapping from the address of each host function pointer to the key of the `HOST_FUNCS`.
 lazy_static! {
-    pub static ref HOST_FUNC_FOOTPRINTS: Mutex<HashMap<usize, usize>> = Mutex::new(HashMap::new());
+    pub(crate) static ref HOST_FUNC_FOOTPRINTS: Mutex<HashMap<usize, usize>> =
+        Mutex::new(HashMap::new());
 }
 
 /// The object that is used to perform a [host function](crate::Function) is required to implement this trait.

--- a/crates/wasmedge-sys/src/lib.rs
+++ b/crates/wasmedge-sys/src/lib.rs
@@ -142,7 +142,7 @@ pub(crate) type BoxedFn = Box<
 >;
 
 lazy_static! {
-    pub(crate) static ref HOST_FUNCS: RwLock<HashMap<usize, Arc<Mutex<BoxedFn>>>> =
+    pub static ref HOST_FUNCS: RwLock<HashMap<usize, Arc<Mutex<BoxedFn>>>> =
         RwLock::new(HashMap::new());
 }
 
@@ -165,8 +165,7 @@ lazy_static! {
 
 // Stores the mapping from the address of each host function pointer to the key of the `HOST_FUNCS`.
 lazy_static! {
-    pub(crate) static ref HOST_FUNC_FOOTPRINTS: Mutex<HashMap<usize, usize>> =
-        Mutex::new(HashMap::new());
+    pub static ref HOST_FUNC_FOOTPRINTS: Mutex<HashMap<usize, usize>> = Mutex::new(HashMap::new());
 }
 
 /// The object that is used to perform a [host function](crate::Function) is required to implement this trait.

--- a/crates/wasmedge-sys/src/lib.rs
+++ b/crates/wasmedge-sys/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! For developers, it is strongly recommended that the APIs in `wasmedge-sys` are used to construct high-level libraries, while `wasmedge-sdk` is for building up business applications.
 //!
-//! * Notice that [wasmedge-sys](https://crates.io/crates/wasmedge-sys) requires **Rust v1.70 or above** in the **stable** channel.
+//! * Notice that [wasmedge-sys](https://crates.io/crates/wasmedge-sys) requires **Rust v1.71 or above** in the **stable** channel.
 //!
 
 //! ## Build
@@ -19,6 +19,7 @@
 //!
 //!   | wasmedge-sdk  | WasmEdge lib  | wasmedge-sys  | wasmedge-types| wasmedge-macro| async-wasi|
 //!   | :-----------: | :-----------: | :-----------: | :-----------: | :-----------: | :-------: |
+//!   | 0.13.0        | 0.13.5        | 0.17.3        | 0.4.4         | 0.6.1         | 0.1.0     |
 //!   | 0.12.2        | 0.13.4        | 0.17.2        | 0.4.4         | 0.6.1         | 0.1.0     |
 //!   | 0.12.1        | 0.13.4        | 0.17.1        | 0.4.4         | 0.6.1         | 0.1.0     |
 //!   | 0.12.0        | 0.13.4        | 0.17.0        | 0.4.4         | 0.6.1         | 0.1.0     |

--- a/src/externals/function.rs
+++ b/src/externals/function.rs
@@ -671,7 +671,8 @@ mod tests {
          -> Box<
             (dyn std::future::Future<Output = Result<Vec<WasmValue>, HostFuncError>> + Send),
         > {
-            let data = unsafe { Box::from_raw(data as *mut Data<i32, &str>) };
+            // Do not use `Box::from_raw`: let data = unsafe { Box::from_raw(data as *mut Data<i32, &str>) };
+            let data = unsafe { &mut *(data as *mut Data<i32, &str>) };
 
             Box::new(async move {
                 for _ in 0..10 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@
 //!
 //! | wasmedge-sdk  | WasmEdge lib  | wasmedge-sys  | wasmedge-types| wasmedge-macro| async-wasi|
 //! | :-----------: | :-----------: | :-----------: | :-----------: | :-----------: | :-------: |
+//! | 0.13.0        | 0.13.5        | 0.17.3        | 0.4.4         | 0.6.1         | 0.1.0     |
 //! | 0.12.2        | 0.13.4        | 0.17.2        | 0.4.4         | 0.6.1         | 0.1.0     |
 //! | 0.12.1        | 0.13.4        | 0.17.1        | 0.4.4         | 0.6.1         | 0.1.0     |
 //! | 0.12.0        | 0.13.4        | 0.17.0        | 0.4.4         | 0.6.1         | 0.1.0     |
@@ -67,7 +68,7 @@
 //!
 //! This crate uses `rust-bindgen` during the build process. If you would like to use an external `rust-bindgen` you can set the `WASMEDGE_RUST_BINDGEN_PATH` environment variable to the `bindgen` executable path. This is particularly useful in systems like Alpine Linux (see [rust-lang/rust-bindgen#2360](https://github.com/rust-lang/rust-bindgen/issues/2360#issuecomment-1595869379), [rust-lang/rust-bindgen#2333](https://github.com/rust-lang/rust-bindgen/issues/2333)).
 //!
-//! **Notice:** The minimum supported Rust version is 1.70.
+//! **Notice:** The minimum supported Rust version is 1.71.
 //!
 //! ## API Reference
 //!

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -505,9 +505,7 @@ impl Vm {
                 Some(named_instance) => {
                     let named_func = named_instance.func(func_name.as_ref())?;
                     let res = named_func.run(self.executor(), args);
-                    dbg!("drop named_func");
                     drop(named_func);
-                    dbg!("DONE! drop anmed_func");
                     res
                 }
                 None => Err(Box::new(WasmEdgeError::Vm(VmError::NotFoundModule(

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -502,9 +502,14 @@ impl Vm {
     ) -> WasmEdgeResult<Vec<WasmValue>> {
         match mod_name {
             Some(mod_name) => match self.named_instances.get(mod_name) {
-                Some(named_instance) => named_instance
-                    .func(func_name.as_ref())?
-                    .run(self.executor(), args),
+                Some(named_instance) => {
+                    let named_func = named_instance.func(func_name.as_ref())?;
+                    let res = named_func.run(self.executor(), args);
+                    dbg!("drop named_func");
+                    drop(named_func);
+                    dbg!("DONE! drop anmed_func");
+                    res
+                }
                 None => Err(Box::new(WasmEdgeError::Vm(VmError::NotFoundModule(
                     mod_name.into(),
                 )))),

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1003,8 +1003,10 @@ mod tests {
         Mutability, NeverType, RefType, Table, TableType, ValType, WasmValue,
     };
 
-    #[cfg(target_os = "linux")]
+    #[ignore]
     #[test]
+    #[cfg(target_os = "linux")]
+    // To enable this test function, please install `wasi_crypto` plugin first.
     fn test_vmbuilder() -> Result<(), Box<dyn std::error::Error>> {
         use crate::{
             config::{CommonConfigOptions, ConfigBuilder, HostRegistrationConfigOptions},


### PR DESCRIPTION
In this PR, the new C-API `WasmEdge_FunctionInstanceGetData` is introduced into the `drop` methods of `ImportModule` and `Function` structs to free host data.

In addition, the following minor changes are involved:

- Bump `wasmedge-sdk` to `0.13.0`
- Update dependencies: `fiber-for-wasmedge v14.04`, `bindgen v0.69`
- Update CI workflows: `Rust` to `1.73`, `macOS` to `macos-13` 