### PR TITLE
Fix static build to link agains zstd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 thiserror = "1.0.30"
 wasmedge-macro.workspace = true
-wasmedge-sys = { path = "crates/wasmedge-sys", version = "0.17", default-features = false }
+wasmedge-sys = { path = "crates/wasmedge-sys", version = "0.17.4", default-features = false }
 wasmedge-types.workspace = true
 
 [workspace.dependencies]

--- a/crates/wasmedge-sys/build.rs
+++ b/crates/wasmedge-sys/build.rs
@@ -98,7 +98,7 @@ fn main() {
         // Tell cargo to tell rustc to link our `wasmedge` library. Cargo will
         // automatically know it must look for a `libwasmedge.a` file.
         println!("cargo:rustc-link-lib=static=wasmedge");
-        for dep in ["rt", "dl", "pthread", "m", "stdc++"] {
+        for dep in ["rt", "dl", "pthread", "m", "zstd", "stdc++"] {
             link_lib(dep);
         }
     } else {


### PR DESCRIPTION
It looks like upstream WasmEdge has zstd as a new dependency.
This is not currently captured in the build script, which results in a linking error when using the `static` feature.
This PR also changes `wasmedge-sys` minimum requirement from `1.7` to `1.7.4` since `wasmedge-sdk` is not compatible with `wasmedge-sys` `1.7.2` (due to the `u64` -> `Duration` change in [here](https://github.com/WasmEdge/wasmedge-rust-sdk/commit/07e84b70ba7e9011ae6774e2ce28c968e25c576a#diff-e10e9fda792a70cad9d8345b8b5c93c30aa4175619742a0e83d606338d65c9beR377))

The missing dependency should have been captured by the `rust-static-lib` CI workflow, but it seems that workflow has never been triggered:
https://github.com/WasmEdge/wasmedge-rust-sdk/actions/workflows/rust-static-lib.yml
This PR makes no attempt at resolving that.