### PR TITLE
[CI] Update `rust-static-lib` workflow

### DIFF
--- a/.github/workflows/rust-static-lib.yml
+++ b/.github/workflows/rust-static-lib.yml
@@ -38,19 +38,6 @@ jobs:
           apt update
           apt install -y software-properties-common libboost-all-dev llvm-15-dev liblld-15-dev ninja-build
 
-      - name: Install Rust-nightly
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: rustfmt, clippy
-
-      - name: Rustfmt
-        run: cargo +nightly fmt --all -- --check
-
-      - name: Clippy
-        run: |
-          cargo +nightly clippy -V
-          cargo +nightly clippy --lib --examples --features static -- -D warnings
-
       - name: Install Rust-stable
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/rust-static-lib.yml
+++ b/.github/workflows/rust-static-lib.yml
@@ -45,8 +45,8 @@ jobs:
 
       - name: Test Rust SDK
         run: |
-          cargo test --workspace --locked --features aot,wasmedge_process,ffi -- --nocapture --test-threads=1
+          cargo test -p wasmedge-sdk --all --examples --features static -- --nocapture --test-threads=1
 
       - name: Test Rust SDK with async feature
         run: |
-          cargo test --workspace --locked --features aot,async,wasmedge_process,ffi -- --nocapture --test-threads=1
+          cargo test -p wasmedge-sdk --all --examples --features static -- --nocapture --test-threads=1

--- a/.github/workflows/rust-static-lib.yml
+++ b/.github/workflows/rust-static-lib.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt update
-          apt install -y software-properties-common libboost-all-dev llvm-15-dev liblld-15-dev ninja-build
+          apt install -y software-properties-common llvm-15-dev liblld-15-dev ninja-build
 
       - name: Install Rust-stable
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/rust-static-lib.yml
+++ b/.github/workflows/rust-static-lib.yml
@@ -25,10 +25,11 @@ jobs:
         os: [ubuntu-22.04]
         rust: [1.73, 1.72, 1.71]
     container:
-      image: wasmedge/wasmedge:latest
+      image: wasmedge/wasmedge:ubuntu-build-clang
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout WasmEdge Rust SDK
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -37,25 +38,16 @@ jobs:
           apt update
           apt install -y software-properties-common libboost-all-dev llvm-15-dev liblld-15-dev ninja-build
 
-      # - name: Build WasmEdge with Release mode
-      #   run: |
-      #     cmake -Bbuild -GNinja -DCMAKE_BUILD_TYPE=Release -DWASMEDGE_LINK_LLVM_STATIC=ON -DWASMEDGE_BUILD_SHARED_LIB=OFF -DWASMEDGE_BUILD_STATIC_LIB=ON -DWASMEDGE_BUILD_TOOLS=OFF -DWASMEDGE_BUILD_PLUGINS=OFF .
-      #     cmake --build build
-
       - name: Install Rust-nightly
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt, clippy
 
       - name: Rustfmt
-        working-directory: bindings/rust/
         run: cargo +nightly fmt --all -- --check
 
       - name: Clippy
-        working-directory: bindings/rust/
         run: |
-          export WASMEDGE_DIR="$(pwd)/../../"
-          export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
           cargo +nightly clippy -V
           cargo +nightly clippy --lib --examples --features static -- -D warnings
 
@@ -64,11 +56,10 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
 
-      - name: Test Rust Bindings
-        working-directory: bindings/rust/
+      - name: Test Rust SDK
         run: |
-          export WASMEDGE_DIR="$(pwd)/../../"
-          export WASMEDGE_BUILD_DIR="$(pwd)/../../build"
-          cargo +nightly -Z sparse-registry update
-          cargo test --workspace --features static --locked -- --test-threads=1
-          cargo test --examples --features static --locked -- --test-threads=1
+          cargo test --workspace --locked --features aot,wasmedge_process,ffi -- --nocapture --test-threads=1
+
+      - name: Test Rust SDK with async feature
+        run: |
+          cargo test --workspace --locked --features aot,async,wasmedge_process,ffi -- --nocapture --test-threads=1

--- a/.github/workflows/rust-static-lib.yml
+++ b/.github/workflows/rust-static-lib.yml
@@ -45,8 +45,8 @@ jobs:
 
       - name: Test Rust SDK
         run: |
-          cargo test -p wasmedge-sdk --all --examples --features static -- --nocapture --test-threads=1
+          cargo test -p wasmedge-sdk --all --examples --features static,aot,wasmedge_process,ffi -- --nocapture --test-threads=1
 
       - name: Test Rust SDK with async feature
         run: |
-          cargo test -p wasmedge-sdk --all --examples --features static -- --nocapture --test-threads=1
+          cargo test -p wasmedge-sdk --all --examples --features static,aot,async,wasmedge_process,ffi -- --nocapture --test-threads=1


### PR DESCRIPTION
In this PR, the `rust-static-lib` workflow is updated to match the latest codebase and fix #92.