### PR TITLE
[Fix] Link fmt library

### DIFF
--- a/crates/wasmedge-sys/build.rs
+++ b/crates/wasmedge-sys/build.rs
@@ -95,9 +95,10 @@ fn main() {
         // Tell cargo to look for static libraries in the specified directory
         println!("cargo:rustc-link-search=native={lib_dir}");
 
-        // Tell cargo to tell rustc to link our `wasmedge` library. Cargo will
-        // automatically know it must look for a `libwasmedge.a` file.
+        // Tell cargo to tell rustc to link our `wasmedge` and `fmt` library. Cargo will
+        // automatically know it must look for a `libwasmedge.a` and `libfmt.a` file.
         println!("cargo:rustc-link-lib=static=wasmedge");
+        println!("cargo:rustc-link-lib=static=fmt");
         for dep in ["rt", "dl", "pthread", "m", "zstd", "stdc++"] {
             link_lib(dep);
         }


### PR DESCRIPTION
Fix [undefined reference to fmtt::v10::***](https://github.com/WasmEdge/WasmEdge/issues/3463) when we static build with wasmedge.