### PR TITLE
fix: gate TimeoutFiberFuture behind not(target_env = "musl")

### DIFF
--- a/crates/wasmedge-sys/build_standalone.rs
+++ b/crates/wasmedge-sys/build_standalone.rs
@@ -127,7 +127,21 @@ fn get_remote_archive() -> Archive {
     debug!("building archive url for target {target}");
     let (sha, slug) = REMOTE_ARCHIVES
         .get(target.as_str())
-        .expect("target not supported with features `standalone` and `static`")
+        .unwrap_or_else(|| {
+            let available: Vec<_> = REMOTE_ARCHIVES.keys().collect();
+            if libc == "musl" && !cfg!(feature = "static") {
+                panic!(
+                    "target '{target}' is not supported. musl targets require the `static` feature. \
+                     Enable it with: wasmedge-sys = {{ features = [\"static\"] }}. \
+                     Available targets: {available:?}"
+                );
+            } else {
+                panic!(
+                    "target '{target}' is not supported with the current feature set. \
+                     Available targets: {available:?}"
+                );
+            }
+        })
         .to_owned();
 
     let asset_name = format!("WasmEdge-{WASMEDGE_RELEASE_VERSION}-{slug}.tar.gz");

--- a/crates/wasmedge-sys/src/async/fiber.rs
+++ b/crates/wasmedge-sys/src/async/fiber.rs
@@ -104,6 +104,11 @@ impl Drop for FiberFuture<'_> {
 }
 
 /// Defines a TimeoutFiberFuture.
+///
+/// Not available on musl targets because it depends on signal-based timeout
+/// mechanisms (sigsetjmp/siglongjmp, timer_create) that are gated behind
+/// `not(target_env = "musl")` in the executor module.
+#[cfg(not(target_env = "musl"))]
 pub(crate) struct TimeoutFiberFuture<'a> {
     fiber: Fiber<'a, Result<(), ()>, (), Result<(), ()>>,
     current_suspend: *mut *const Suspend<Result<(), ()>, (), Result<(), ()>>,
@@ -111,6 +116,7 @@ pub(crate) struct TimeoutFiberFuture<'a> {
     deadline: std::time::SystemTime,
 }
 
+#[cfg(not(target_env = "musl"))]
 impl<'a> TimeoutFiberFuture<'a> {
     /// Create a fiber to execute the given function.
     ///
@@ -164,6 +170,7 @@ impl<'a> TimeoutFiberFuture<'a> {
     }
 }
 
+#[cfg(not(target_env = "musl"))]
 impl Future for TimeoutFiberFuture<'_> {
     type Output = Result<(), ()>;
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -225,9 +232,12 @@ impl Future for TimeoutFiberFuture<'_> {
         }
     }
 }
+#[cfg(not(target_env = "musl"))]
 unsafe impl Send for TimeoutFiberFuture<'_> {}
+#[cfg(not(target_env = "musl"))]
 unsafe impl Sync for TimeoutFiberFuture<'_> {}
 
+#[cfg(not(target_env = "musl"))]
 impl Drop for TimeoutFiberFuture<'_> {
     fn drop(&mut self) {
         if !self.fiber.done() {


### PR DESCRIPTION
## Problem

`TimeoutFiberFuture` in `crates/wasmedge-sys/src/async/fiber.rs` references `JmpState`, `JMP_BUF`, `init_signal_listen`, and `timeout_signo` from the executor module. These are all gated behind `#[cfg(not(target_env = "musl"))]` in `executor.rs`, but `TimeoutFiberFuture` itself has no musl gate.

This causes a compilation error on musl targets with the `async` feature:
```
error[E0425]: cannot find value `JMP_BUF` in module `crate::executor`
```

## Fix

Gate all `TimeoutFiberFuture` definitions (struct, impls, Send, Sync, Drop) with `#[cfg(not(target_env = "musl"))]`, matching the existing gates on the executor symbols it depends on.

Also improves the `build_standalone.rs` error message when a target is not found in `REMOTE_ARCHIVES`. For musl targets without the `static` feature, the error now explains that musl requires `static` and lists available targets.

## Testing

- `cargo check -p wasmedge-sys --features async,standalone` passes on macOS (no behavior change on non-musl)
- The musl gate matches the existing pattern used throughout `executor.rs`

Signed-off-by: Michael Yuan <michael@secondstate.io>