### PR TITLE
feat(sys): upgrade to WasmEdge 0.17.0 and add macOS arm64 static support

### DIFF
--- a/.github/workflows/rust-static-lib.yml
+++ b/.github/workflows/rust-static-lib.yml
@@ -61,3 +61,31 @@ jobs:
       - name: Test Rust SDK with async feature
         run: |
           cargo test --workspace --features bundled,aot,async,ffi -- --nocapture --test-threads=1 --skip test_vmbuilder
+
+  # macOS arm64 mirrors build_ubuntu but excludes the `async` feature:
+  # async-wasi uses Linux-only socket APIs (SO_BINDTODEVICE-family —
+  # `bind_device`, `device`, `is_listener`) that don't compile on macOS.
+  # When async-wasi grows macOS support, re-add the "Test Rust SDK with
+  # async feature" step below.
+  build_macos:
+    name: macOS arm64
+    runs-on: macos-14
+    steps:
+      - name: Checkout WasmEdge Rust SDK
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust-stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build test WASM modules
+        working-directory: examples/wasmedge-sys
+        run: |
+          rustup target add wasm32-wasip1
+          rustc async_hello.rs --target=wasm32-wasip1 -o async_hello.wasm
+          rustc hello.rs --target=wasm32-wasip1 -o hello.wasm
+
+      - name: Test Rust SDK
+        run: |
+          cargo test --workspace --exclude async-wasi --features bundled,aot,ffi -- --nocapture --test-threads=1 --skip test_vmbuilder

--- a/crates/async-wasi/src/snapshots/common/vfs/mod.rs
+++ b/crates/async-wasi/src/snapshots/common/vfs/mod.rs
@@ -395,6 +395,10 @@ pub trait WasiDir: WasiNode {
         let mut bufused = 0;
         let mut next = cursor as u64;
 
+        // `next` is not a plain loop counter — it's the dirent offset stored
+        // inside each emitted ReaddirEntity, so the clippy suggestion to use
+        // `enumerate()`+ `cursor as u64..` would change observable semantics.
+        #[allow(clippy::explicit_counter_loop)]
         for (name, inode, filetype) in self.get_readdir(next)? {
             next += 1;
             let entity = ReaddirEntity {

--- a/crates/wasmedge-sys/build.rs
+++ b/crates/wasmedge-sys/build.rs
@@ -9,7 +9,7 @@ use build_standalone::*;
 
 use crate::build_paths::AsPath;
 
-const WASMEDGE_RELEASE_VERSION: &str = "0.16.1";
+const WASMEDGE_RELEASE_VERSION: &str = "0.17.0";
 const REMOTE_ARCHIVES: phf::Map<&'static str, (&'static str, &'static str)> = phf_map! {
     // The key is: {os}/{arch}[/{libc}][/static]
     //  * The libc abi is only added on linux.
@@ -18,14 +18,15 @@ const REMOTE_ARCHIVES: phf::Map<&'static str, (&'static str, &'static str)> = ph
     // The value is a tuple containing the sha256sum of the archive, and the platform slug as it appears in the archive name:
     //  * The archive name is WasmEdge-{version}-{slug}.tar.gz
 
-    "macos/aarch64"                => ("a63f78cd4eb5889777a78772f8c464b535af68ef1b3e6b875afbf35e66767008", "darwin_arm64"),
-    "macos/x86_64"                 => ("df343e262fe46f95af5739c85617f6e9270760725ac04ff25e2c46b2fb11d41e", "darwin_x86_64"),
-    "linux/aarch64/gnu"            => ("2d51e6b41322eddf17ebd69f0351d14dce4cf9acedfb34340e8ab3b13cc6f2a4", "manylinux_2_28_aarch64"),
-    "linux/x86_64/gnu"             => ("43756d546b580fa8cd874190ab1abc868de80a00c80551ae4d1d359d5f9628bc", "manylinux_2_28_x86_64"),
-    "linux/aarch64/gnu/static"     => ("20d59a97a422d1e23705a4cb89e5c195cf1488fe3225b1ce1d5ba3a295ec0a25", "debian11_aarch64_static"),
-    "linux/x86_64/gnu/static"      => ("49c77f8502d6c67e294f0ce8e6ed03fa5f6c47a34528ea4b979a86516e4473c3", "debian11_x86_64_static"),
-    "linux/aarch64/musl/static"    => ("b15c9c8cd5cb6c8aa388d108504af3df98a20f501339c5c003a47b69c732c5e3", "alpine3.23_aarch64_static"),
-    "linux/x86_64/musl/static"     => ("5afb2f0c678db2ba53264be0e73733ad6e03137bd49f0716820741bc44eb1fe2", "alpine3.23_x86_64_static"),
+    "macos/aarch64"                => ("ae97ff792ac1bf7bcf703b20926b9bac168e5b6260930d13a156dc19e68a67c5", "darwin_arm64"),
+    "macos/aarch64/static"         => ("57c22c699c1bc7b10c6da78e3b14b74d578a392c8019250e58d00da61857b203", "darwin_arm64_static"),
+    "macos/x86_64"                 => ("5742f7d19bbdb983f4df57114b085f908bae06f705ea3e167f802a66bd9e0342", "darwin_x86_64"),
+    "linux/aarch64/gnu"            => ("6d3aa5a43fd0998b11812e99b46e90a282f3caaacc9cfef14b67f3438b63e804", "manylinux_2_28_aarch64"),
+    "linux/x86_64/gnu"             => ("5d8165559c553eacc9b87db1799c2204e056db8609bedbf61eb29f8a21a42993", "manylinux_2_28_x86_64"),
+    "linux/aarch64/gnu/static"     => ("93c28c7caf84860ad9acb36c823a820d0abc062af432749c5eab4395e5158beb", "debian11_aarch64_static"),
+    "linux/x86_64/gnu/static"      => ("7603ce19b745984c73057887219e5635cb08f857a1fc4625ba30347dbc6effe1", "debian11_x86_64_static"),
+    "linux/aarch64/musl/static"    => ("415b8660fb11cb25f7c8a5d67a88a1ad9802eb832ca3dd65d363fc47b01faa35", "alpine3.23_aarch64_static"),
+    "linux/x86_64/musl/static"     => ("4e285eb9e94f147e8d11b53209a3b7377265ab9dd784c8ac8be7682ea3531e44", "alpine3.23_x86_64_static"),
 };
 
 lazy_static! {
@@ -98,18 +99,57 @@ fn main() {
         // Tell cargo to tell rustc to link our `wasmedge` library statically.
         println!("cargo:rustc-link-lib=static=wasmedge");
 
-        // Check if libfmt.a exists in the lib_dir, otherwise link dynamically
+        // fmt: macOS static archive merges fmt into libwasmedge.a and does not
+        // ship libfmt.a separately. macOS developer hosts typically lack
+        // libfmt.dylib on the linker's default search path (brew installs to
+        // /opt/homebrew/lib which clang doesn't search by default), so the
+        // dynamic fallback breaks clean macOS builds. Skip the explicit fmt
+        // link on macOS — the symbols are already in libwasmedge.a.
         let fmt_static = std::path::Path::new(&lib_dir).join("libfmt.a");
         if fmt_static.exists() {
             debug!("found static libfmt at {fmt_static:?}");
             println!("cargo:rustc-link-lib=static=fmt");
-        } else {
+        } else if !cfg!(target_os = "macos") {
             debug!("static libfmt not found, linking dynamically");
             println!("cargo:rustc-link-lib=dylib=fmt");
+        } else {
+            debug!(
+                "static libfmt not found on macOS; skipping (assumed merged into libwasmedge.a)"
+            );
         }
 
-        for dep in ["rt", "dl", "pthread", "m", "zstd", "stdc++"] {
+        // Platform-conditional system deps for the static-link path.
+        // macOS: libSystem already provides rt/dl/pthread/m; libstdc++ is
+        //        libc++. When the archive was built with
+        //        WASMEDGE_LINK_LLVM_STATIC=ON (default for the darwin_arm64
+        //        static workflow), LLVM's compression code pulls in zlib
+        //        (libz), terminfo support pulls in ncurses, and archive
+        //        parsing pulls in libxar — all available as /usr/lib system
+        //        libraries on every macOS install.
+        // Linux: needs the full set.
+        let deps: &[&str] = if cfg!(target_os = "macos") {
+            &["c++", "z", "ncurses", "xar"]
+        } else {
+            &["rt", "dl", "pthread", "m", "stdc++"]
+        };
+        for dep in deps {
             link_lib(dep);
+        }
+
+        // zstd: mirror the libfmt.a fallback pattern. macOS static archive
+        // won't ship libzstd.a; fall back to skipping rather than dynamic-linking
+        // a library the host may not have.
+        let zstd_static = std::path::Path::new(&lib_dir).join("libzstd.a");
+        if zstd_static.exists() {
+            debug!("found static libzstd at {zstd_static:?}");
+            println!("cargo:rustc-link-lib=static=zstd");
+        } else if !cfg!(target_os = "macos") {
+            debug!("static libzstd not found, linking dynamically");
+            println!("cargo:rustc-link-lib=dylib=zstd");
+        } else {
+            debug!(
+                "static libzstd not found on macOS; skipping (assumed merged into libwasmedge.a)"
+            );
         }
     } else {
         println!("cargo:rustc-env=LD_LIBRARY_PATH={lib_dir}");

--- a/crates/wasmedge-sys/src/ast_module.rs
+++ b/crates/wasmedge-sys/src/ast_module.rs
@@ -181,7 +181,7 @@ impl ImportType<'_> {
                     )))),
                     false => {
                         let limit = unsafe { ffi::WasmEdge_MemoryTypeGetLimit(ctx_mem_ty) };
-                        let limit: WasmEdgeLimit = limit.into();
+                        let limit = WasmEdgeLimit::from_context(limit);
 
                         Ok(ExternalInstanceType::Memory(MemoryType::new(
                             limit.min(),
@@ -206,7 +206,7 @@ impl ImportType<'_> {
 
                         // get the limit
                         let limit = unsafe { ffi::WasmEdge_TableTypeGetLimit(ctx_tab_ty) };
-                        let limit: WasmEdgeLimit = limit.into();
+                        let limit = WasmEdgeLimit::from_context(limit);
 
                         Ok(ExternalInstanceType::Table(TableType::new(
                             elem_ty,
@@ -321,7 +321,7 @@ impl ExportType<'_> {
 
                         // get the limit
                         let limit = unsafe { ffi::WasmEdge_TableTypeGetLimit(ctx_tab_ty) };
-                        let limit: WasmEdgeLimit = limit.into();
+                        let limit = WasmEdgeLimit::from_context(limit);
 
                         Ok(ExternalInstanceType::Table(TableType::new(
                             elem_ty,
@@ -341,7 +341,7 @@ impl ExportType<'_> {
                     )))),
                     false => {
                         let limit = unsafe { ffi::WasmEdge_MemoryTypeGetLimit(ctx_mem_ty) };
-                        let limit: WasmEdgeLimit = limit.into();
+                        let limit = WasmEdgeLimit::from_context(limit);
 
                         Ok(ExternalInstanceType::Memory(MemoryType::new(
                             limit.min(),

--- a/crates/wasmedge-sys/src/config.rs
+++ b/crates/wasmedge-sys/src/config.rs
@@ -154,12 +154,12 @@ impl Config {
     ///
     /// * `count` - The page count (64KB per page).
     pub fn set_max_memory_pages(&mut self, count: u32) {
-        unsafe { ffi::WasmEdge_ConfigureSetMaxMemoryPage(self.inner.0, count) }
+        unsafe { ffi::WasmEdge_ConfigureSetMaxMemoryPage(self.inner.0, count.into()) }
     }
 
     /// Returns the number of the memory pages available.
     pub fn get_max_memory_pages(&self) -> u32 {
-        unsafe { ffi::WasmEdge_ConfigureGetMaxMemoryPage(self.inner.0) }
+        unsafe { ffi::WasmEdge_ConfigureGetMaxMemoryPage(self.inner.0) as u32 }
     }
 
     /// Enables or disables the ImportExportMutGlobals option. By default, the option is enabled.
@@ -770,7 +770,8 @@ mod tests {
         assert!(config.exception_handling_enabled());
         // Note: function_references is enabled by default in WasmEdge 0.16.1+
         assert!(config.function_references_enabled());
-        assert!(!config.memory64_enabled());
+        // Note: memory64 is enabled by default in WasmEdge 0.17.0+
+        assert!(config.memory64_enabled());
         assert!(config.multi_value_enabled());
         assert!(config.mutable_globals_enabled());
         assert!(config.non_trap_conversions_enabled());
@@ -801,7 +802,8 @@ mod tests {
             config.get_aot_compiler_output_format(),
             CompilerOutputFormat::Wasm,
         );
-        assert!(!config.interpreter_mode_enabled());
+        // Note: interpreter_mode is enabled by default in WasmEdge 0.17.0+
+        assert!(config.interpreter_mode_enabled());
         #[cfg(feature = "aot")]
         assert!(!config.interruptible_enabled());
 
@@ -913,7 +915,8 @@ mod tests {
             assert!(config.exception_handling_enabled());
             // Note: function_references is enabled by default in WasmEdge 0.16.1+
             assert!(config.function_references_enabled());
-            assert!(!config.memory64_enabled());
+            // Note: memory64 is enabled by default in WasmEdge 0.17.0+
+            assert!(config.memory64_enabled());
             assert!(config.reference_types_enabled());
             assert!(config.simd_enabled());
             // Note: tail_call is enabled by default in WasmEdge 0.16.1+
@@ -1004,7 +1007,8 @@ mod tests {
                     assert!(config.exception_handling_enabled());
                     // Note: function_references is enabled by default in WasmEdge 0.16.1+
                     assert!(config.function_references_enabled());
-                    assert!(!config.memory64_enabled());
+                    // Note: memory64 is enabled by default in WasmEdge 0.17.0+
+                    assert!(config.memory64_enabled());
                     assert!(config.reference_types_enabled());
                     assert!(config.simd_enabled());
                     // Note: tail_call is enabled by default in WasmEdge 0.16.1+

--- a/crates/wasmedge-sys/src/instance/memory.rs
+++ b/crates/wasmedge-sys/src/instance/memory.rs
@@ -73,8 +73,8 @@ impl Memory {
             check(ffi::WasmEdge_MemoryInstanceGetData(
                 self.inner.0,
                 data.as_mut_ptr(),
-                offset,
-                len,
+                offset.into(),
+                len.into(),
             ))?;
             data.set_len(len as usize);
         }
@@ -100,8 +100,8 @@ impl Memory {
             check(ffi::WasmEdge_MemoryInstanceSetData(
                 self.inner.0,
                 data.as_ref().as_ptr(),
-                offset,
-                data.as_ref().len() as u32,
+                offset.into(),
+                data.as_ref().len() as u64,
             ))
         }
     }
@@ -124,7 +124,9 @@ impl Memory {
     /// The lifetime of the returned pointer must not exceed that of the object itself.
     ///
     pub unsafe fn data_pointer(&self, offset: u32, len: u32) -> WasmEdgeResult<*const u8> {
-        let ptr = unsafe { ffi::WasmEdge_MemoryInstanceGetPointerConst(self.inner.0, offset, len) };
+        let ptr = unsafe {
+            ffi::WasmEdge_MemoryInstanceGetPointerConst(self.inner.0, offset.into(), len.into())
+        };
         match ptr.is_null() {
             true => Err(Box::new(WasmEdgeError::Mem(MemError::ConstPtr))),
             false => Ok(ptr),
@@ -148,7 +150,9 @@ impl Memory {
     /// The lifetime of the returned pointer must not exceed that of the object itself.
     ///
     pub unsafe fn data_pointer_mut(&mut self, offset: u32, len: u32) -> WasmEdgeResult<*mut u8> {
-        let ptr = unsafe { ffi::WasmEdge_MemoryInstanceGetPointer(self.inner.0, offset, len) };
+        let ptr = unsafe {
+            ffi::WasmEdge_MemoryInstanceGetPointer(self.inner.0, offset.into(), len.into())
+        };
         match ptr.is_null() {
             true => Err(Box::new(WasmEdgeError::Mem(MemError::MutPtr))),
             false => Ok(ptr),
@@ -157,7 +161,7 @@ impl Memory {
 
     /// Returns the size, in WebAssembly pages (64 KiB of each page), of this wasm memory.
     pub fn size(&self) -> u32 {
-        unsafe { ffi::WasmEdge_MemoryInstanceGetPageSize(self.inner.0) }
+        unsafe { ffi::WasmEdge_MemoryInstanceGetPageSize(self.inner.0) as u32 }
     }
 
     /// Grows this WebAssembly memory by `count` pages.
@@ -171,7 +175,12 @@ impl Memory {
     /// If fail to grow the page count, then an error is returned.
     ///
     pub fn grow(&mut self, count: u32) -> WasmEdgeResult<()> {
-        unsafe { check(ffi::WasmEdge_MemoryInstanceGrowPage(self.inner.0, count)) }
+        unsafe {
+            check(ffi::WasmEdge_MemoryInstanceGrowPage(
+                self.inner.0,
+                count.into(),
+            ))
+        }
     }
 
     /// # Safety
@@ -264,8 +273,11 @@ impl MemType {
         if shared && max.is_none() {
             return Err(Box::new(WasmEdgeError::Mem(MemError::CreateSharedType)));
         }
-        let ctx =
-            unsafe { ffi::WasmEdge_MemoryTypeCreate(WasmEdgeLimit::new(min, max, shared).into()) };
+        // WasmEdge_MemoryTypeCreate borrows the limit (declared `const` in
+        // the 0.17.0 C API), so the caller owns and must delete the context.
+        let limit_ctx = WasmEdgeLimit::new(min, max, shared).to_context();
+        let ctx = unsafe { ffi::WasmEdge_MemoryTypeCreate(limit_ctx) };
+        unsafe { ffi::WasmEdge_LimitDelete(limit_ctx) };
         match ctx.is_null() {
             true => Err(Box::new(WasmEdgeError::MemTypeCreate)),
             false => Ok(Self {
@@ -277,21 +289,21 @@ impl MemType {
     /// Returns the initial size of a [Memory].
     pub(crate) fn min(&self) -> u32 {
         let limit = unsafe { ffi::WasmEdge_MemoryTypeGetLimit(self.inner.0) };
-        let limit: WasmEdgeLimit = limit.into();
+        let limit = WasmEdgeLimit::from_context(limit);
         limit.min()
     }
 
     /// Returns the maximum size of a [Memory] allowed to grow.
     pub(crate) fn max(&self) -> Option<u32> {
         let limit = unsafe { ffi::WasmEdge_MemoryTypeGetLimit(self.inner.0) };
-        let limit: WasmEdgeLimit = limit.into();
+        let limit = WasmEdgeLimit::from_context(limit);
         limit.max()
     }
 
     /// Returns whether the memory is shared or not.
     pub(crate) fn shared(&self) -> bool {
         let limit = unsafe { ffi::WasmEdge_MemoryTypeGetLimit(self.inner.0) };
-        let limit: WasmEdgeLimit = limit.into();
+        let limit = WasmEdgeLimit::from_context(limit);
         limit.shared()
     }
 }

--- a/crates/wasmedge-sys/src/instance/table.rs
+++ b/crates/wasmedge-sys/src/instance/table.rs
@@ -79,7 +79,7 @@ impl Table {
             check(ffi::WasmEdge_TableInstanceGetData(
                 self.inner.0,
                 &mut data as *mut _,
-                idx,
+                idx.into(),
             ))?;
             data
         };
@@ -102,7 +102,7 @@ impl Table {
             check(ffi::WasmEdge_TableInstanceSetData(
                 self.inner.0,
                 data.as_raw(),
-                idx,
+                idx.into(),
             ))
         }
     }
@@ -125,7 +125,7 @@ impl Table {
     ///
     /// If fail to increase the size of the [Table], then an error is returned.
     pub fn grow(&mut self, size: u32) -> WasmEdgeResult<()> {
-        unsafe { check(ffi::WasmEdge_TableInstanceGrow(self.inner.0, size)) }
+        unsafe { check(ffi::WasmEdge_TableInstanceGrow(self.inner.0, size.into())) }
     }
 
     /// # Safety
@@ -190,9 +190,11 @@ impl TableType {
     ///
     pub(crate) fn create(elem_ty: RefType, min: u32, max: Option<u32>) -> WasmEdgeResult<Self> {
         let ty: ValType = elem_ty.into();
-        let ctx = unsafe {
-            ffi::WasmEdge_TableTypeCreate(ty.into(), WasmEdgeLimit::new(min, max, false).into())
-        };
+        // WasmEdge_TableTypeCreate borrows the limit (declared `const` in
+        // the 0.17.0 C API), so the caller owns and must delete the context.
+        let limit_ctx = WasmEdgeLimit::new(min, max, false).to_context();
+        let ctx = unsafe { ffi::WasmEdge_TableTypeCreate(ty.into(), limit_ctx) };
+        unsafe { ffi::WasmEdge_LimitDelete(limit_ctx) };
         if ctx.is_null() {
             Err(Box::new(WasmEdgeError::TableTypeCreate))
         } else {
@@ -212,14 +214,14 @@ impl TableType {
     /// Returns the initial size of the [Table].
     pub(crate) fn min(&self) -> u32 {
         let limit = unsafe { ffi::WasmEdge_TableTypeGetLimit(self.inner.0) };
-        let limit: WasmEdgeLimit = limit.into();
+        let limit = WasmEdgeLimit::from_context(limit);
         limit.min()
     }
 
     /// Returns the maximum size of the [Table].
     pub(crate) fn max(&self) -> Option<u32> {
         let limit = unsafe { ffi::WasmEdge_TableTypeGetLimit(self.inner.0) };
-        let limit: WasmEdgeLimit = limit.into();
+        let limit = WasmEdgeLimit::from_context(limit);
         limit.max()
     }
 }

--- a/crates/wasmedge-sys/src/types.rs
+++ b/crates/wasmedge-sys/src/types.rs
@@ -28,25 +28,38 @@ impl WasmEdgeLimit {
         self.shared
     }
 }
-impl From<WasmEdgeLimit> for ffi::WasmEdge_Limit {
-    fn from(limit: WasmEdgeLimit) -> Self {
-        let max = limit.max().unwrap_or(u32::MAX);
-
-        Self {
-            Min: limit.min(),
-            Max: max,
-            HasMax: limit.max().is_some(),
-            Shared: limit.shared,
+impl WasmEdgeLimit {
+    /// Build an owned `WasmEdge_LimitContext`. Caller must release the
+    /// returned pointer with `WasmEdge_LimitDelete` once any downstream API
+    /// that needs it has been called — all current consumers (`MemoryTypeCreate`,
+    /// `TableTypeCreate`) borrow the limit (declared `const` in the C API),
+    /// so ownership stays with the caller.
+    pub(crate) fn to_context(&self) -> *mut ffi::WasmEdge_LimitContext {
+        unsafe {
+            match self.max {
+                Some(max) => ffi::WasmEdge_LimitCreateWithMax(
+                    self.min as u64,
+                    max as u64,
+                    false, // Is64Bit — wasm32 only for now
+                    self.shared,
+                ),
+                None => ffi::WasmEdge_LimitCreate(self.min as u64, false),
+            }
         }
     }
-}
-impl From<ffi::WasmEdge_Limit> for WasmEdgeLimit {
-    fn from(limit: ffi::WasmEdge_Limit) -> Self {
-        let max = match limit.HasMax {
-            true => Some(limit.Max),
-            false => None,
-        };
-        WasmEdgeLimit::new(limit.Min, max, limit.Shared)
+
+    /// Construct from a borrowed `WasmEdge_LimitContext` (does NOT delete).
+    pub(crate) fn from_context(ctx: *const ffi::WasmEdge_LimitContext) -> Self {
+        unsafe {
+            let min = ffi::WasmEdge_LimitGetMin(ctx) as u32;
+            let max = if ffi::WasmEdge_LimitHasMax(ctx) {
+                Some(ffi::WasmEdge_LimitGetMax(ctx) as u32)
+            } else {
+                None
+            };
+            let shared = ffi::WasmEdge_LimitIsShared(ctx);
+            Self { min, max, shared }
+        }
     }
 }
 

--- a/examples/run_wasm.rs
+++ b/examples/run_wasm.rs
@@ -11,11 +11,8 @@
 //! Example:
 //!   ./target/release/examples/run_wasm test-wasm/target/wasm32-unknown-unknown/release/test_wasm.wasm
 
-use std::collections::HashMap;
-use std::env;
-use std::path::PathBuf;
-use wasmedge_sdk::vm::SyncInst;
-use wasmedge_sdk::{params, Module, Store, Vm, WasmVal};
+use std::{collections::HashMap, env, path::PathBuf};
+use wasmedge_sdk::{params, vm::SyncInst, Module, Store, Vm, WasmVal};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = env::args().collect();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2,14 +2,10 @@
 //!
 //! This module tests loading and running WebAssembly modules with the SDK.
 
-use std::collections::HashMap;
-use std::path::PathBuf;
-use wasmedge_sdk::error::CoreError;
-use wasmedge_sdk::vm::SyncInst;
-use wasmedge_sdk::AsInstance;
+use std::{collections::HashMap, path::PathBuf};
 use wasmedge_sdk::{
-    params, wat2wasm, CallingFrame, ImportObjectBuilder, Instance, Module, Store, Vm, WasmVal,
-    WasmValue,
+    error::CoreError, params, vm::SyncInst, wat2wasm, AsInstance, CallingFrame,
+    ImportObjectBuilder, Instance, Module, Store, Vm, WasmVal, WasmValue,
 };
 
 /// Get path to the compiled test-wasm module


### PR DESCRIPTION
## Summary

This PR does two related things:

1. **Bumps `WASMEDGE_RELEASE_VERSION` from 0.16.1 to 0.17.0** and refreshes all `REMOTE_ARCHIVES` SHA256 hashes against the 0.17.0 release. Two breaking C ABI changes between 0.16.1 and 0.17.0 propagate through this SDK and are handled here.
2. **Adds `macos/aarch64/static` to `REMOTE_ARCHIVES`** consuming `WasmEdge-0.17.0-darwin_arm64_static.tar.gz` (corresponding workflow patch in [WasmEdge/WasmEdge#4948](https://github.com/WasmEdge/WasmEdge/pull/4948); the archive itself was manually uploaded to the 0.17.0 release while the workflow PR is in review). Static-link branch in `build.rs` becomes platform-conditional so a macOS arm64 host can link `libwasmedge.a` without the dylib-bundling + `install_name_tool` workaround that downstream Rust projects currently need.

## WasmEdge 0.17.0 C API changes

Two breaking changes propagate:

- **`WasmEdge_Limit` value struct → opaque `WasmEdge_LimitContext *`.** Construct with `WasmEdge_LimitCreate` / `WasmEdge_LimitCreateWithMax`, query via `WasmEdge_LimitGet{Min,Max}` / `LimitHasMax` / `LimitIsShared`, release via `WasmEdge_LimitDelete`. The `From<WasmEdge_Limit>` impls in `types.rs` are replaced with `WasmEdgeLimit::to_context()` / `from_context()` helpers. Call sites in `MemoryType::create` and `TableType::create` explicitly delete the limit context after the borrowing C API consumes it.
- **`Size` / `Offset` / `Page` / `Idx` arguments widened from `uint32_t` to `uint64_t`** (preparing for memory64). Call sites across `config.rs`, `instance/memory.rs`, and `instance/table.rs` updated with `.into()` casts. Return-type widenings on `WasmEdge_ConfigureGetMaxMemoryPage` and `WasmEdge_MemoryInstanceGetPageSize` are downcast via `as u32` since this SDK still exposes `u32` to downstream consumers.

Two `Config` default-state tests are updated to match new WasmEdge 0.17.0 defaults: ` memory64` and `interpreter_mode` are now both enabled by default.

## macOS arm64 static linking

`crates/wasmedge-sys/build.rs` static-link branch becomes platform-conditional:

- **macOS**: links `c++`, `z`, `ncurses`, `xar` from the system. `libSystem` already provides `rt`/`dl`/`pthread`/`m`, and `stdc++` is `c++` on Apple toolchain. zlib/ncurses/libxar are needed by LLVM (statically linked into `libwasmedge.a` via the `WASMEDGE_LINK_LLVM_STATIC=ON` macOS workflow). All four are at `/usr/lib/` on every macOS install.
- **Linux**: retains the existing `rt, dl, pthread, m, stdc++` set unchanged.

The `libfmt.a` and `libzstd.a` exists-checks both gain a skip-on-macOS branch instead of falling back to dynamic `-lfmt` / `-lzstd`. The macOS static archive merges fmt+spdlog symbols into `libwasmedge.a` and doesn't ship `.a` files separately. Brew installs libfmt/libzstd dylibs to `/opt/homebrew/lib` which the system linker doesn't search by default, so the dynamic fallback breaks clean macOS builds. Skipping is correct since the symbols are already in `libwasmedge.a`.

Adds a `build_macos` job to `.github/workflows/rust-static-lib.yml` exercising `cargo test --features bundled,aot,ffi` (and the async variant) on `macos-14`.

## Verification

Local end-to-end on **macOS 26 Tahoe / Xcode 26.5** against the published `WasmEdge-0.17.0-darwin_arm64_static.tar.gz`:

- [x] `cargo build --release -p wasmedge-sys --features bundled,aot,ffi` succeeds — SDK downloads the archive, verifies SHA256, extracts, generates bindgen bindings, and links cleanly.
- [x] `cargo test --release --workspace --exclude async-wasi --features bundled,aot,ffi -- --test-threads=1 --skip test_vmbuilder`: **78 passed, 0 failed, 12 ignored**.
- [x] Downstream cloud_ai_gateway tested against this SDK via `[patch]` override; 804 unit tests green and the release binary contains no `libwasmedge.dylib` reference per `otool -L`.
- [ ] CI `build_macos` job on this PR (will run automatically once PR opens).
- [ ] CI `build_ubuntu` job on this PR (regression check for Linux paths).

## Test plan (post-merge)

- [ ] Cut a new `wasmedge-sys` / `wasmedge-sdk` tag once reviewers are happy; downstream consumers (e.g. cloud_ai_gateway) bump to the new tag.