### PR TITLE
ci: migrate crate releases to trusted publishing

### DIFF
--- a/.github/workflows/release-async-wasi.yml
+++ b/.github/workflows/release-async-wasi.yml
@@ -46,7 +46,7 @@ jobs:
       contents: read
       id-token: write
     container:
-      image: wasmedge/wasmedge:ubuntu-build-clang
+      image: wasmedge/wasmedge:ubuntu-build-clang@sha256:a5cacfd0cd2d9ff2ba28f6581ab7dff3e4053145556f7e99b05249e9b7323d5b
 
     steps:
       - name: Checkout WasmEdge Rust SDK

--- a/.github/workflows/release-async-wasi.yml
+++ b/.github/workflows/release-async-wasi.yml
@@ -1,16 +1,11 @@
 name: Release async-wasi crate
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
-
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       dry_run:
         description: "Validate the release without publishing or deploying documentation"
         required: true
-        default: true
         type: boolean
 
 jobs:
@@ -37,14 +32,6 @@ jobs:
         run: |
           cargo publish --dry-run -p async-wasi
 
-      - name: Publish
-        if: github.ref == 'refs/heads/main' && inputs.dry_run == false
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRIES_ASYNC_WASI_TOKEN }}
-        shell: bash
-        run: |
-          cargo publish -p async-wasi
-
       - name: Build API document
         run: |
           cargo doc -p async-wasi --no-deps --target-dir=./target
@@ -57,10 +44,43 @@ jobs:
           path: target/doc
           if-no-files-found: error
 
+  publish_async_wasi:
+    name: Publish async-wasi crate
+    if: github.ref == 'refs/heads/main' && inputs.dry_run == false
+    needs: release_async_wasi
+    runs-on: ubuntu-22.04
+    environment: crates-io
+    permissions:
+      contents: read
+      id-token: write
+    container:
+      image: wasmedge/wasmedge:ubuntu-build-clang
+
+    steps:
+      - name: Checkout WasmEdge Rust SDK
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Rust-stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Authenticate with crates.io
+        id: crates_io_auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
+      - name: Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates_io_auth.outputs.token }}
+        shell: bash
+        run: |
+          cargo publish -p async-wasi
+
   deploy_api_document:
     name: Deploy API document
     if: github.ref == 'refs/heads/main' && inputs.dry_run == false
-    needs: release_async_wasi
+    needs: [release_async_wasi, publish_async_wasi]
     runs-on: ubuntu-22.04
     permissions:
       contents: write

--- a/.github/workflows/release-async-wasi.yml
+++ b/.github/workflows/release-async-wasi.yml
@@ -36,14 +36,6 @@ jobs:
         run: |
           cargo doc -p async-wasi --no-deps --target-dir=./target
 
-      - name: Upload API document
-        if: github.ref == 'refs/heads/main' && inputs.dry_run == false
-        uses: actions/upload-artifact@v7
-        with:
-          name: async-wasi-api-docs
-          path: target/doc
-          if-no-files-found: error
-
   publish_async_wasi:
     name: Publish async-wasi crate
     if: github.ref == 'refs/heads/main' && inputs.dry_run == false
@@ -76,26 +68,3 @@ jobs:
         shell: bash
         run: |
           cargo publish -p async-wasi
-
-  deploy_api_document:
-    name: Deploy API document
-    if: github.ref == 'refs/heads/main' && inputs.dry_run == false
-    needs: [release_async_wasi, publish_async_wasi]
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: write
-
-    steps:
-      - name: Download API document
-        uses: actions/download-artifact@v8
-        with:
-          name: async-wasi-api-docs
-          path: target/doc
-
-      - name: Deploy API document
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
-          publish_dir: target/doc
-          force_orphan: true

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -192,7 +192,7 @@ jobs:
           path: target/doc
 
       - name: Deploy API document
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -1,0 +1,169 @@
+name: Release crates
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_async_wasi:
+        description: "Release async-wasi"
+        required: true
+        default: false
+        type: boolean
+      release_wasmedge_macro:
+        description: "Release wasmedge-macro"
+        required: true
+        default: false
+        type: boolean
+      release_wasmedge_types:
+        description: "Release wasmedge-types"
+        required: true
+        default: false
+        type: boolean
+      release_wasmedge_sys:
+        description: "Release wasmedge-sys"
+        required: true
+        default: false
+        type: boolean
+      release_wasmedge_sdk:
+        description: "Release wasmedge-sdk"
+        required: true
+        default: false
+        type: boolean
+      wasmedge_version:
+        description: "WasmEdge version (required for wasmedge-sys or wasmedge-sdk)"
+        required: false
+        type: string
+      dry_run:
+        description: "Validate selected releases without publishing or deploying documentation"
+        required: true
+        default: true
+        type: boolean
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  validate_inputs:
+    name: Validate release inputs
+    runs-on: ubuntu-latest
+    permissions: {}
+    env:
+      DRY_RUN: ${{ inputs.dry_run }}
+      RELEASE_ASYNC_WASI: ${{ inputs.release_async_wasi }}
+      RELEASE_WASMEDGE_MACRO: ${{ inputs.release_wasmedge_macro }}
+      RELEASE_WASMEDGE_TYPES: ${{ inputs.release_wasmedge_types }}
+      RELEASE_WASMEDGE_SYS: ${{ inputs.release_wasmedge_sys }}
+      RELEASE_WASMEDGE_SDK: ${{ inputs.release_wasmedge_sdk }}
+      WASMEDGE_VERSION: ${{ inputs.wasmedge_version }}
+      WORKFLOW_REF: ${{ github.ref }}
+
+    steps:
+      - name: Validate selection and version
+        shell: bash
+        run: |
+          if [[ "${RELEASE_ASYNC_WASI}" != "true" \
+            && "${RELEASE_WASMEDGE_MACRO}" != "true" \
+            && "${RELEASE_WASMEDGE_TYPES}" != "true" \
+            && "${RELEASE_WASMEDGE_SYS}" != "true" \
+            && "${RELEASE_WASMEDGE_SDK}" != "true" ]]; then
+            echo "::error::Select at least one crate to release."
+            exit 1
+          fi
+
+          if [[ ("${RELEASE_WASMEDGE_SYS}" == "true" || "${RELEASE_WASMEDGE_SDK}" == "true") \
+            && -z "${WASMEDGE_VERSION}" ]]; then
+            echo "::error::wasmedge_version is required when releasing wasmedge-sys or wasmedge-sdk."
+            exit 1
+          fi
+
+          if [[ "${DRY_RUN}" == "false" && "${WORKFLOW_REF}" != "refs/heads/main" ]]; then
+            echo "::error::Publishing is only allowed from the main branch."
+            exit 1
+          fi
+
+  release_async_wasi:
+    name: Release async-wasi
+    needs: validate_inputs
+    if: inputs.release_async_wasi
+    permissions:
+      contents: write
+      id-token: write
+    uses: ./.github/workflows/release-async-wasi.yml
+    with:
+      dry_run: ${{ inputs.dry_run }}
+
+  release_wasmedge_macro:
+    name: Release wasmedge-macro
+    needs: validate_inputs
+    if: inputs.release_wasmedge_macro
+    permissions:
+      contents: write
+      id-token: write
+    uses: ./.github/workflows/release-wasmedge-macro.yml
+    with:
+      dry_run: ${{ inputs.dry_run }}
+
+  release_wasmedge_types:
+    name: Release wasmedge-types
+    needs: validate_inputs
+    if: inputs.release_wasmedge_types
+    permissions:
+      contents: write
+      id-token: write
+    uses: ./.github/workflows/release-wasmedge-types.yml
+    with:
+      dry_run: ${{ inputs.dry_run }}
+
+  release_wasmedge_sys:
+    name: Release wasmedge-sys
+    needs:
+      - validate_inputs
+      - release_async_wasi
+      - release_wasmedge_macro
+      - release_wasmedge_types
+    if: >-
+      ${{
+        always() &&
+        !cancelled() &&
+        inputs.release_wasmedge_sys &&
+        needs.validate_inputs.result == 'success' &&
+        (needs.release_async_wasi.result == 'success' || needs.release_async_wasi.result == 'skipped') &&
+        (needs.release_wasmedge_macro.result == 'success' || needs.release_wasmedge_macro.result == 'skipped') &&
+        (needs.release_wasmedge_types.result == 'success' || needs.release_wasmedge_types.result == 'skipped')
+      }}
+    permissions:
+      contents: write
+      id-token: write
+    uses: ./.github/workflows/release-wasmedge-sys.yml
+    with:
+      wasmedge_version: ${{ inputs.wasmedge_version }}
+      dry_run: ${{ inputs.dry_run }}
+
+  release_wasmedge_sdk:
+    name: Release wasmedge-sdk
+    needs:
+      - validate_inputs
+      - release_async_wasi
+      - release_wasmedge_macro
+      - release_wasmedge_types
+      - release_wasmedge_sys
+    if: >-
+      ${{
+        always() &&
+        !cancelled() &&
+        inputs.release_wasmedge_sdk &&
+        needs.validate_inputs.result == 'success' &&
+        (needs.release_async_wasi.result == 'success' || needs.release_async_wasi.result == 'skipped') &&
+        (needs.release_wasmedge_macro.result == 'success' || needs.release_wasmedge_macro.result == 'skipped') &&
+        (needs.release_wasmedge_types.result == 'success' || needs.release_wasmedge_types.result == 'skipped') &&
+        (needs.release_wasmedge_sys.result == 'success' || needs.release_wasmedge_sys.result == 'skipped')
+      }}
+    permissions:
+      contents: write
+      id-token: write
+    uses: ./.github/workflows/release-wasmedge-sdk.yml
+    with:
+      wasmedge_version: ${{ inputs.wasmedge_version }}
+      dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -167,3 +167,34 @@ jobs:
     with:
       wasmedge_version: ${{ inputs.wasmedge_version }}
       dry_run: ${{ inputs.dry_run }}
+
+  deploy_api_document:
+    name: Deploy API document
+    needs: release_wasmedge_sdk
+    if: >-
+      ${{
+        always() &&
+        !cancelled() &&
+        github.ref == 'refs/heads/main' &&
+        inputs.release_wasmedge_sdk &&
+        inputs.dry_run == false &&
+        needs.release_wasmedge_sdk.result == 'success'
+      }}
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download API document
+        uses: actions/download-artifact@v8
+        with:
+          name: wasmedge-sdk-api-docs
+          path: target/doc
+
+      - name: Deploy API document
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: target/doc
+          force_orphan: true

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -88,7 +88,7 @@ jobs:
     needs: validate_inputs
     if: inputs.release_async_wasi
     permissions:
-      contents: write
+      contents: read
       id-token: write
     uses: ./.github/workflows/release-async-wasi.yml
     with:
@@ -99,7 +99,7 @@ jobs:
     needs: validate_inputs
     if: inputs.release_wasmedge_macro
     permissions:
-      contents: write
+      contents: read
       id-token: write
     uses: ./.github/workflows/release-wasmedge-macro.yml
     with:
@@ -110,7 +110,7 @@ jobs:
     needs: validate_inputs
     if: inputs.release_wasmedge_types
     permissions:
-      contents: write
+      contents: read
       id-token: write
     uses: ./.github/workflows/release-wasmedge-types.yml
     with:
@@ -134,7 +134,7 @@ jobs:
         (needs.release_wasmedge_types.result == 'success' || needs.release_wasmedge_types.result == 'skipped')
       }}
     permissions:
-      contents: write
+      contents: read
       id-token: write
     uses: ./.github/workflows/release-wasmedge-sys.yml
     with:
@@ -161,7 +161,7 @@ jobs:
         (needs.release_wasmedge_sys.result == 'success' || needs.release_wasmedge_sys.result == 'skipped')
       }}
     permissions:
-      contents: write
+      contents: read
       id-token: write
     uses: ./.github/workflows/release-wasmedge-sdk.yml
     with:

--- a/.github/workflows/release-wasmedge-macro.yml
+++ b/.github/workflows/release-wasmedge-macro.yml
@@ -69,7 +69,7 @@ jobs:
       contents: read
       id-token: write
     container:
-      image: wasmedge/wasmedge:ubuntu-build-clang
+      image: wasmedge/wasmedge:ubuntu-build-clang@sha256:a5cacfd0cd2d9ff2ba28f6581ab7dff3e4053145556f7e99b05249e9b7323d5b
 
     steps:
       - name: Checkout WasmEdge Rust SDK

--- a/.github/workflows/release-wasmedge-macro.yml
+++ b/.github/workflows/release-wasmedge-macro.yml
@@ -59,14 +59,6 @@ jobs:
         run: |
           cargo doc -p wasmedge-macro --no-deps --target-dir=./target
 
-      - name: Upload API document
-        if: github.ref == 'refs/heads/main' && inputs.dry_run == false
-        uses: actions/upload-artifact@v7
-        with:
-          name: wasmedge-macro-api-docs
-          path: target/doc
-          if-no-files-found: error
-
   publish_wasmedge_macro:
     name: Publish wasmedge-macro crate
     if: github.ref == 'refs/heads/main' && inputs.dry_run == false
@@ -99,26 +91,3 @@ jobs:
         shell: bash
         run: |
           cargo publish -p wasmedge-macro
-
-  deploy_api_document:
-    name: Deploy API document
-    if: github.ref == 'refs/heads/main' && inputs.dry_run == false
-    needs: [release_wasmedge_macro, publish_wasmedge_macro]
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: write
-
-    steps:
-      - name: Download API document
-        uses: actions/download-artifact@v8
-        with:
-          name: wasmedge-macro-api-docs
-          path: target/doc
-
-      - name: Deploy API document
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
-          publish_dir: target/doc
-          force_orphan: true

--- a/.github/workflows/release-wasmedge-macro.yml
+++ b/.github/workflows/release-wasmedge-macro.yml
@@ -1,16 +1,11 @@
 name: Release wasmedge-macro crate
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
-
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       dry_run:
         description: "Validate the release without publishing or deploying documentation"
         required: true
-        default: true
         type: boolean
 
 jobs:
@@ -60,14 +55,6 @@ jobs:
         run: |
           cargo publish --dry-run -p wasmedge-macro
 
-      - name: Publish
-        if: github.ref == 'refs/heads/main' && inputs.dry_run == false
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRIES_MACRO_TOKEN }}
-        shell: bash
-        run: |
-          cargo publish -p wasmedge-macro
-
       - name: Build API document
         run: |
           cargo doc -p wasmedge-macro --no-deps --target-dir=./target
@@ -80,10 +67,43 @@ jobs:
           path: target/doc
           if-no-files-found: error
 
+  publish_wasmedge_macro:
+    name: Publish wasmedge-macro crate
+    if: github.ref == 'refs/heads/main' && inputs.dry_run == false
+    needs: release_wasmedge_macro
+    runs-on: ubuntu-22.04
+    environment: crates-io
+    permissions:
+      contents: read
+      id-token: write
+    container:
+      image: wasmedge/wasmedge:ubuntu-build-clang
+
+    steps:
+      - name: Checkout WasmEdge Rust SDK
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Rust-stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Authenticate with crates.io
+        id: crates_io_auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
+      - name: Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates_io_auth.outputs.token }}
+        shell: bash
+        run: |
+          cargo publish -p wasmedge-macro
+
   deploy_api_document:
     name: Deploy API document
     if: github.ref == 'refs/heads/main' && inputs.dry_run == false
-    needs: release_wasmedge_macro
+    needs: [release_wasmedge_macro, publish_wasmedge_macro]
     runs-on: ubuntu-22.04
     permissions:
       contents: write

--- a/.github/workflows/release-wasmedge-sdk.yml
+++ b/.github/workflows/release-wasmedge-sdk.yml
@@ -166,26 +166,3 @@ jobs:
         shell: bash
         run: |
           cargo publish -p wasmedge-sdk
-
-  deploy_api_document:
-    name: Deploy API document
-    if: github.ref == 'refs/heads/main' && inputs.dry_run == false
-    needs: [release_wasmedge_sdk, publish_wasmedge_sdk]
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: write
-
-    steps:
-      - name: Download API document
-        uses: actions/download-artifact@v8
-        with:
-          name: wasmedge-sdk-api-docs
-          path: target/doc
-
-      - name: Deploy API document
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
-          publish_dir: target/doc
-          force_orphan: true

--- a/.github/workflows/release-wasmedge-sdk.yml
+++ b/.github/workflows/release-wasmedge-sdk.yml
@@ -128,7 +128,7 @@ jobs:
       contents: read
       id-token: write
     container:
-      image: wasmedge/wasmedge:ubuntu-build-clang
+      image: wasmedge/wasmedge:ubuntu-build-clang@sha256:a5cacfd0cd2d9ff2ba28f6581ab7dff3e4053145556f7e99b05249e9b7323d5b
 
     steps:
       - name: Checkout WasmEdge Rust SDK

--- a/.github/workflows/release-wasmedge-sdk.yml
+++ b/.github/workflows/release-wasmedge-sdk.yml
@@ -1,11 +1,7 @@
 name: Release wasmedge-sdk crate
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
-
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       wasmedge_version:
         description: "Version of WasmEdge"
@@ -14,7 +10,6 @@ on:
       dry_run:
         description: "Validate the release without publishing or deploying documentation"
         required: true
-        default: true
         type: boolean
 
 jobs:
@@ -111,14 +106,6 @@ jobs:
         run: |
           cargo publish --dry-run -p wasmedge-sdk
 
-      - name: Publish
-        if: github.ref == 'refs/heads/main' && inputs.dry_run == false
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRIES_SDK_TOKEN }}
-        shell: bash
-        run: |
-          cargo publish -p wasmedge-sdk
-
       - name: Build API document
         run: |
           RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc -p wasmedge-sdk --workspace --no-deps --features aot,wasi_crypto,wasi_nn,wasmedge_process,ffi --target-dir=./target
@@ -131,10 +118,59 @@ jobs:
           path: target/doc
           if-no-files-found: error
 
+  publish_wasmedge_sdk:
+    name: Publish wasmedge-sdk crate
+    if: github.ref == 'refs/heads/main' && inputs.dry_run == false
+    needs: release_wasmedge_sdk
+    runs-on: ubuntu-22.04
+    environment: crates-io
+    permissions:
+      contents: read
+      id-token: write
+    container:
+      image: wasmedge/wasmedge:ubuntu-build-clang
+
+    steps:
+      - name: Checkout WasmEdge Rust SDK
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up build environment
+        run: |
+          apt update
+          apt install -y software-properties-common libboost-all-dev ninja-build
+          apt install -y llvm-15-dev liblld-15-dev
+
+      - name: Install WasmEdge
+        env:
+          WASMEDGE_VERSION: ${{ inputs.wasmedge_version }}
+        run: |
+          curl -sSfL --retry 3 --output /tmp/wasmedge-install.sh \
+            https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh
+          bash /tmp/wasmedge-install.sh -v "${WASMEDGE_VERSION}" -p /usr/local
+          ldconfig
+          /usr/local/bin/wasmedge --version
+
+      - name: Install Rust-nightly
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Authenticate with crates.io
+        id: crates_io_auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
+      - name: Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates_io_auth.outputs.token }}
+        shell: bash
+        run: |
+          cargo publish -p wasmedge-sdk
+
   deploy_api_document:
     name: Deploy API document
     if: github.ref == 'refs/heads/main' && inputs.dry_run == false
-    needs: release_wasmedge_sdk
+    needs: [release_wasmedge_sdk, publish_wasmedge_sdk]
     runs-on: ubuntu-22.04
     permissions:
       contents: write

--- a/.github/workflows/release-wasmedge-sdk.yml
+++ b/.github/workflows/release-wasmedge-sdk.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install WasmEdge
         run: |
           curl -sSfL --retry 3 --output /tmp/wasmedge-install.sh \
-            https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh
+            https://raw.githubusercontent.com/WasmEdge/WasmEdge/678e63744c8a774eb68695f6c496c4bcf802f850/utils/install_v2.sh
           bash /tmp/wasmedge-install.sh -v "${WASMEDGE_VERSION}" -p "$HOME/.wasmedge"
           "$HOME/.wasmedge/bin/wasmedge" --version
           echo "WASMEDGE_DIR=$HOME/.wasmedge" >> "$GITHUB_ENV"
@@ -83,7 +83,7 @@ jobs:
           WASMEDGE_VERSION: ${{ inputs.wasmedge_version }}
         run: |
           curl -sSfL --retry 3 --output /tmp/wasmedge-install.sh \
-            https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh
+            https://raw.githubusercontent.com/WasmEdge/WasmEdge/678e63744c8a774eb68695f6c496c4bcf802f850/utils/install_v2.sh
           bash /tmp/wasmedge-install.sh -v "${WASMEDGE_VERSION}" -p /usr/local
           ldconfig
           /usr/local/bin/wasmedge --version
@@ -147,8 +147,9 @@ jobs:
         env:
           WASMEDGE_VERSION: ${{ inputs.wasmedge_version }}
         run: |
+          # Pin remote code executed in this OIDC-enabled publish job.
           curl -sSfL --retry 3 --output /tmp/wasmedge-install.sh \
-            https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh
+            https://raw.githubusercontent.com/WasmEdge/WasmEdge/678e63744c8a774eb68695f6c496c4bcf802f850/utils/install_v2.sh
           bash /tmp/wasmedge-install.sh -v "${WASMEDGE_VERSION}" -p /usr/local
           ldconfig
           /usr/local/bin/wasmedge --version

--- a/.github/workflows/release-wasmedge-sys.yml
+++ b/.github/workflows/release-wasmedge-sys.yml
@@ -1,11 +1,7 @@
 name: Release wasmedge-sys crate
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
-
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       wasmedge_version:
         description: "Version of WasmEdge"
@@ -14,7 +10,6 @@ on:
       dry_run:
         description: "Validate the release without publishing or deploying documentation"
         required: true
-        default: true
         type: boolean
 
 jobs:
@@ -95,14 +90,6 @@ jobs:
         run: |
           cargo publish --dry-run -p wasmedge-sys
 
-      - name: Publish
-        if: github.ref == 'refs/heads/main' && inputs.dry_run == false
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRIES_SYS_TOKEN }}
-        shell: bash
-        run: |
-          cargo publish -p wasmedge-sys
-
       - name: Build API document
         run: |
           RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc -p wasmedge-sys --workspace --no-deps --features aot,wasi_crypto,wasi_nn,wasmedge_process,ffi --target-dir=./target
@@ -115,10 +102,59 @@ jobs:
           path: target/doc
           if-no-files-found: error
 
+  publish_wasmedge_sys:
+    name: Publish wasmedge-sys crate
+    if: github.ref == 'refs/heads/main' && inputs.dry_run == false
+    needs: release_wasmedge_sys
+    runs-on: ubuntu-22.04
+    environment: crates-io
+    permissions:
+      contents: read
+      id-token: write
+    container:
+      image: wasmedge/wasmedge:ubuntu-build-clang
+
+    steps:
+      - name: Checkout WasmEdge Rust SDK
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up build environment
+        run: |
+          apt update
+          apt install -y software-properties-common libboost-all-dev ninja-build
+          apt install -y llvm-15-dev liblld-15-dev
+
+      - name: Install WasmEdge
+        env:
+          WASMEDGE_VERSION: ${{ inputs.wasmedge_version }}
+        run: |
+          curl -sSfL --retry 3 --output /tmp/wasmedge-install.sh \
+            https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh
+          bash /tmp/wasmedge-install.sh -v "${WASMEDGE_VERSION}" -p /usr/local
+          ldconfig
+          /usr/local/bin/wasmedge --version
+
+      - name: Install Rust-nightly
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Authenticate with crates.io
+        id: crates_io_auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
+      - name: Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates_io_auth.outputs.token }}
+        shell: bash
+        run: |
+          cargo publish -p wasmedge-sys
+
   deploy_api_document:
     name: Deploy API document
     if: github.ref == 'refs/heads/main' && inputs.dry_run == false
-    needs: release_wasmedge_sys
+    needs: [release_wasmedge_sys, publish_wasmedge_sys]
     runs-on: ubuntu-22.04
     permissions:
       contents: write

--- a/.github/workflows/release-wasmedge-sys.yml
+++ b/.github/workflows/release-wasmedge-sys.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install WasmEdge
         run: |
           curl -sSfL --retry 3 --output /tmp/wasmedge-install.sh \
-            https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh
+            https://raw.githubusercontent.com/WasmEdge/WasmEdge/678e63744c8a774eb68695f6c496c4bcf802f850/utils/install_v2.sh
           bash /tmp/wasmedge-install.sh -v "${WASMEDGE_VERSION}" -p "$HOME/.wasmedge"
           "$HOME/.wasmedge/bin/wasmedge" --version
           echo "WASMEDGE_DIR=$HOME/.wasmedge" >> "$GITHUB_ENV"
@@ -83,7 +83,7 @@ jobs:
           WASMEDGE_VERSION: ${{ inputs.wasmedge_version }}
         run: |
           curl -sSfL --retry 3 --output /tmp/wasmedge-install.sh \
-            https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh
+            https://raw.githubusercontent.com/WasmEdge/WasmEdge/678e63744c8a774eb68695f6c496c4bcf802f850/utils/install_v2.sh
           bash /tmp/wasmedge-install.sh -v "${WASMEDGE_VERSION}" -p /usr/local
           ldconfig
           /usr/local/bin/wasmedge --version
@@ -139,8 +139,9 @@ jobs:
         env:
           WASMEDGE_VERSION: ${{ inputs.wasmedge_version }}
         run: |
+          # Pin remote code executed in this OIDC-enabled publish job.
           curl -sSfL --retry 3 --output /tmp/wasmedge-install.sh \
-            https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh
+            https://raw.githubusercontent.com/WasmEdge/WasmEdge/678e63744c8a774eb68695f6c496c4bcf802f850/utils/install_v2.sh
           bash /tmp/wasmedge-install.sh -v "${WASMEDGE_VERSION}" -p /usr/local
           ldconfig
           /usr/local/bin/wasmedge --version

--- a/.github/workflows/release-wasmedge-sys.yml
+++ b/.github/workflows/release-wasmedge-sys.yml
@@ -42,7 +42,14 @@ jobs:
       - name: Install Rust-nightly
         uses: dtolnay/rust-toolchain@nightly
 
+      # Workspace dependency versions may not exist on crates.io until the
+      # preceding release workflows complete.
+      - name: Validate package contents
+        if: inputs.dry_run
+        run: cargo package --list -p wasmedge-sys
+
       - name: Dry run cargo publish
+        if: inputs.dry_run == false
         run: cargo publish --dry-run -p wasmedge-sys
 
       - name: Build API document
@@ -85,7 +92,16 @@ jobs:
       - name: Install Rust-nightly
         uses: dtolnay/rust-toolchain@nightly
 
+      # Workspace dependency versions may not exist on crates.io until the
+      # preceding release workflows complete.
+      - name: Validate package contents
+        if: inputs.dry_run
+        shell: bash
+        run: |
+          cargo package --list -p wasmedge-sys
+
       - name: Dry run cargo publish
+        if: inputs.dry_run == false
         shell: bash
         run: |
           cargo publish --dry-run -p wasmedge-sys
@@ -93,14 +109,6 @@ jobs:
       - name: Build API document
         run: |
           RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc -p wasmedge-sys --workspace --no-deps --features aot,wasi_crypto,wasi_nn,wasmedge_process,ffi --target-dir=./target
-
-      - name: Upload API document
-        if: github.ref == 'refs/heads/main' && inputs.dry_run == false
-        uses: actions/upload-artifact@v7
-        with:
-          name: wasmedge-sys-api-docs
-          path: target/doc
-          if-no-files-found: error
 
   publish_wasmedge_sys:
     name: Publish wasmedge-sys crate
@@ -150,26 +158,3 @@ jobs:
         shell: bash
         run: |
           cargo publish -p wasmedge-sys
-
-  deploy_api_document:
-    name: Deploy API document
-    if: github.ref == 'refs/heads/main' && inputs.dry_run == false
-    needs: [release_wasmedge_sys, publish_wasmedge_sys]
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: write
-
-    steps:
-      - name: Download API document
-        uses: actions/download-artifact@v8
-        with:
-          name: wasmedge-sys-api-docs
-          path: target/doc
-
-      - name: Deploy API document
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
-          publish_dir: target/doc
-          force_orphan: true

--- a/.github/workflows/release-wasmedge-sys.yml
+++ b/.github/workflows/release-wasmedge-sys.yml
@@ -120,7 +120,7 @@ jobs:
       contents: read
       id-token: write
     container:
-      image: wasmedge/wasmedge:ubuntu-build-clang
+      image: wasmedge/wasmedge:ubuntu-build-clang@sha256:a5cacfd0cd2d9ff2ba28f6581ab7dff3e4053145556f7e99b05249e9b7323d5b
 
     steps:
       - name: Checkout WasmEdge Rust SDK

--- a/.github/workflows/release-wasmedge-types.yml
+++ b/.github/workflows/release-wasmedge-types.yml
@@ -69,7 +69,7 @@ jobs:
       contents: read
       id-token: write
     container:
-      image: wasmedge/wasmedge:ubuntu-build-clang
+      image: wasmedge/wasmedge:ubuntu-build-clang@sha256:a5cacfd0cd2d9ff2ba28f6581ab7dff3e4053145556f7e99b05249e9b7323d5b
 
     steps:
       - name: Checkout WasmEdge Rust SDK

--- a/.github/workflows/release-wasmedge-types.yml
+++ b/.github/workflows/release-wasmedge-types.yml
@@ -59,14 +59,6 @@ jobs:
         run: |
           cargo doc -p wasmedge-types --no-deps --target-dir=./target
 
-      - name: Upload API document
-        if: github.ref == 'refs/heads/main' && inputs.dry_run == false
-        uses: actions/upload-artifact@v7
-        with:
-          name: wasmedge-types-api-docs
-          path: target/doc
-          if-no-files-found: error
-
   publish_wasmedge_types:
     name: Publish wasmedge-types crate
     if: github.ref == 'refs/heads/main' && inputs.dry_run == false
@@ -99,26 +91,3 @@ jobs:
         shell: bash
         run: |
           cargo publish -p wasmedge-types
-
-  deploy_api_document:
-    name: Deploy API document
-    if: github.ref == 'refs/heads/main' && inputs.dry_run == false
-    needs: [release_wasmedge_types, publish_wasmedge_types]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
-    steps:
-      - name: Download API document
-        uses: actions/download-artifact@v8
-        with:
-          name: wasmedge-types-api-docs
-          path: target/doc
-
-      - name: Deploy API document
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
-          publish_dir: target/doc
-          force_orphan: true

--- a/.github/workflows/release-wasmedge-types.yml
+++ b/.github/workflows/release-wasmedge-types.yml
@@ -1,16 +1,11 @@
 name: Release wasmedge-types crate
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
-
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       dry_run:
         description: "Validate the release without publishing or deploying documentation"
         required: true
-        default: true
         type: boolean
 
 jobs:
@@ -60,14 +55,6 @@ jobs:
         run: |
           cargo publish --dry-run -p wasmedge-types
 
-      - name: Publish
-        if: github.ref == 'refs/heads/main' && inputs.dry_run == false
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRIES_TYPES_TOKEN }}
-        shell: bash
-        run: |
-          cargo publish -p wasmedge-types
-
       - name: Build API document
         run: |
           cargo doc -p wasmedge-types --no-deps --target-dir=./target
@@ -80,10 +67,43 @@ jobs:
           path: target/doc
           if-no-files-found: error
 
+  publish_wasmedge_types:
+    name: Publish wasmedge-types crate
+    if: github.ref == 'refs/heads/main' && inputs.dry_run == false
+    needs: release_wasmedge_types
+    runs-on: ubuntu-latest
+    environment: crates-io
+    permissions:
+      contents: read
+      id-token: write
+    container:
+      image: wasmedge/wasmedge:ubuntu-build-clang
+
+    steps:
+      - name: Checkout WasmEdge Rust SDK
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Rust-stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Authenticate with crates.io
+        id: crates_io_auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
+      - name: Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates_io_auth.outputs.token }}
+        shell: bash
+        run: |
+          cargo publish -p wasmedge-types
+
   deploy_api_document:
     name: Deploy API document
     if: github.ref == 'refs/heads/main' && inputs.dry_run == false
-    needs: release_wasmedge_types
+    needs: [release_wasmedge_types, publish_wasmedge_types]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Replace the five long-lived crate-specific registry secrets with GitHub OIDC and the official `rust-lang/crates-io-auth-action`, pinned to a full commit SHA.
- Keep `id-token: write` scoped to dedicated publish jobs using the `crates-io` GitHub Environment.
- Add `.github/workflows/release-crates.yml` as the single manual release entry point and convert the five per-crate release workflows to reusable workflows.
- Encode the publish dependency graph with `needs`:
  - `async-wasi`, `wasmedge-macro`, and `wasmedge-types` may publish in parallel.
  - `wasmedge-sys` waits for the selected base crates.
  - `wasmedge-sdk` waits for the selected base crates and `wasmedge-sys`.
- Preserve targeted recovery through the per-crate selection inputs on `release-crates.yml`, while validating required versions and ensuring real publishing only runs from `main`.
- Serialize releases without cancelling an in-progress publish, and deploy documentation only after the SDK publish succeeds.

## Why

Long-lived crates.io tokens increase the impact of secret leakage and require manual rotation. Trusted Publishing exchanges GitHub's short-lived OIDC identity for a scoped crates.io token at publish time.

The crates also have a real registry publish order because Cargo replaces local path dependencies with their versioned crates.io dependencies when packaging. Independent release workflows could therefore publish `wasmedge-sys` or `wasmedge-sdk` before their prerequisites were available. The new orchestrator makes that order explicit.

Publishing is separated from validation so only the minimal jobs receive permission to request an OIDC token.

## Impact

The manual release entry point becomes `release-crates.yml`. It defaults to dry-run mode and requires explicitly selecting at least one crate, so failed releases can be recovered by re-running failed jobs or dispatching only the unfinished crate and any downstream dependents.

Before the first real publish, complete these one-time settings:

1. Create a protected GitHub Environment named `crates-io`.
2. Configure a trusted publisher for each crate on crates.io with:
   - Owner: `WasmEdge`
   - Repository: `wasmedge-rust-sdk`
   - Workflow: `release-crates.yml`
   - Environment: `crates-io`
3. After a successful migration, enable “Require trusted publishing for all new versions” and remove the legacy secrets:
   - `CARGO_REGISTRIES_ASYNC_WASI_TOKEN`
   - `CARGO_REGISTRIES_WASMEDGE_MACRO_TOKEN`
   - `CARGO_REGISTRIES_WASMEDGE_TYPES_TOKEN`
   - `CARGO_REGISTRIES_WASMEDGE_SYS_TOKEN`
   - `CARGO_REGISTRIES_WASMEDGE_SDK_TOKEN`

Reference: https://crates.io/docs/trusted-publishing

## Validation

- `actionlint v1.7.12` on all six changed workflow files
- YAML parsing for all workflow files
- `git diff --check`
- Dependency graph assertion for base crates → `wasmedge-sys` → `wasmedge-sdk`
- Repository scan confirming no remaining references to the legacy crates.io secrets
