### PR TITLE
feat: add run-mode support

### DIFF
--- a/.github/workflows/ci-build-release-lib.yml
+++ b/.github/workflows/ci-build-release-lib.yml
@@ -6,6 +6,9 @@ concurrency:
 
 env:
   WASMEDGE_VERSION: "0.17.1"
+  # .rustfmt.toml relies on nightly-only options (imports_granularity,
+  # group_imports, ...) that stable rustfmt silently ignores.
+  RUSTFMT_TOOLCHAIN: "nightly-2026-07-16"
 
 on:
   push:
@@ -52,7 +55,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
 
       - name: Rustfmt
-        run: cargo fmt --all -- --check
+        run: |
+          rustup toolchain install ${{ env.RUSTFMT_TOOLCHAIN }} --profile minimal --component rustfmt
+          cargo +${{ env.RUSTFMT_TOOLCHAIN }} fmt --all -- --check
 
       - name: Clippy check
         run: |
@@ -108,7 +113,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
 
       - name: Run cargo fmt
-        run: cargo fmt --all -- --check
+        run: |
+          rustup toolchain install ${{ env.RUSTFMT_TOOLCHAIN }} --profile minimal --component rustfmt
+          cargo +${{ env.RUSTFMT_TOOLCHAIN }} fmt --all -- --check
 
       - name: Clippy
         run: |
@@ -172,7 +179,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
 
       - name: Rustfmt
-        run: cargo fmt --all -- --check
+        run: |
+          rustup toolchain install ${{ env.RUSTFMT_TOOLCHAIN }} --profile minimal --component rustfmt
+          cargo +${{ env.RUSTFMT_TOOLCHAIN }} fmt --all -- --check
 
       - name: Clippy
         run: |

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -4,6 +4,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+env:
+  # .rustfmt.toml relies on nightly-only options (imports_granularity,
+  # group_imports, ...) that stable rustfmt silently ignores.
+  RUSTFMT_TOOLCHAIN: "nightly-2026-07-16"
+
 on:
   push:
     branches:
@@ -59,7 +64,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
 
       - name: Rustfmt
-        run: cargo fmt --all -- --check
+        run: |
+          rustup toolchain install ${{ env.RUSTFMT_TOOLCHAIN }} --profile minimal --component rustfmt
+          cargo +${{ env.RUSTFMT_TOOLCHAIN }} fmt --all -- --check
 
       - name: Clippy check
         run: |
@@ -127,7 +134,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
 
       - name: Run cargo fmt
-        run: cargo fmt --all -- --check
+        run: |
+          rustup toolchain install ${{ env.RUSTFMT_TOOLCHAIN }} --profile minimal --component rustfmt
+          cargo +${{ env.RUSTFMT_TOOLCHAIN }} fmt --all -- --check
 
       - name: Clippy
         run: |
@@ -188,7 +197,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
 
       - name: Rustfmt
-        run: cargo fmt --all -- --check
+        run: |
+          rustup toolchain install ${{ env.RUSTFMT_TOOLCHAIN }} --profile minimal --component rustfmt
+          cargo +${{ env.RUSTFMT_TOOLCHAIN }} fmt --all -- --check
 
       - name: Clippy
         run: |

--- a/crates/wasmedge-sys/src/compiler.rs
+++ b/crates/wasmedge-sys/src/compiler.rs
@@ -158,7 +158,7 @@ mod tests {
     };
     use wasmedge_types::{
         error::{CoreError, CoreLoadError},
-        wat2wasm, CompilerOptimizationLevel, CompilerOutputFormat,
+        wat2wasm, CompilerOptimizationLevel, CompilerOutputFormat, RunMode,
     };
 
     #[test]
@@ -422,6 +422,9 @@ mod tests {
         config.set_aot_optimization_level(CompilerOptimizationLevel::O0);
         config.set_aot_compiler_output_format(CompilerOutputFormat::Native);
         config.interruptible(true);
+        // run the compiled module in AOT mode (since WasmEdge 0.17.0, the
+        // default mode is interpreter, which ignores the AOT-compiled code)
+        config.set_run_mode(RunMode::Aot);
 
         // create an executor
         let mut executor = Executor::create(Some(&config), None)?;

--- a/crates/wasmedge-sys/src/config.rs
+++ b/crates/wasmedge-sys/src/config.rs
@@ -1,7 +1,7 @@
 //! Defines WasmEdge Config struct.
 
 use crate::{ffi, WasmEdgeResult};
-use wasmedge_types::error::WasmEdgeError;
+use wasmedge_types::{error::WasmEdgeError, RunMode};
 #[cfg(feature = "aot")]
 use wasmedge_types::{CompilerOptimizationLevel, CompilerOutputFormat};
 
@@ -119,6 +119,12 @@ use wasmedge_types::{CompilerOptimizationLevel, CompilerOutputFormat};
 ///     - `cost_measuring` determines if measuring the instruction costs when running a compiled or pure WASM.
 ///
 ///     - `time_measuring` determines if measuring the running time when running a compiled or pure WASM.
+///
+/// - **Execution Mode**
+///     - `run_mode` selects the engine used to execute a WASM module: interpreter (default), JIT, or AOT.
+///
+///       Since WasmEdge 0.17.0, only the AOT mode loads the AOT custom sections from a universal WASM
+///       file or `dlopen`s a shared-library WASM artifact; in the other modes, the AOT data is ignored.
 ///
 /// API users can first set the options of interest, such as those related to the WebAssembly proposals,
 /// host registrations, AOT compiler options, and etc., then apply the configuration
@@ -554,16 +560,45 @@ impl Config {
         }
     }
 
+    /// Sets the execution mode: interpreter, JIT, or AOT. By default, the mode is
+    /// [RunMode::Interpreter].
+    ///
+    /// Since WasmEdge 0.17.0, only [RunMode::Aot] loads the AOT custom sections from a universal
+    /// WASM file or `dlopen`s a shared-library WASM artifact; in the other modes, the AOT data is
+    /// ignored and the WASM runs in the selected engine.
+    ///
+    /// # Argument
+    ///
+    /// * `mode` - The execution mode to set.
+    pub fn set_run_mode(&mut self, mode: RunMode) {
+        unsafe {
+            ffi::WasmEdge_ConfigureSetRunMode(
+                self.inner.0,
+                u32::from(mode) as ffi::WasmEdge_RunMode,
+            )
+        }
+    }
+
+    /// Returns the execution mode.
+    pub fn get_run_mode(&self) -> RunMode {
+        let mode = unsafe { ffi::WasmEdge_ConfigureGetRunMode(self.inner.0) };
+        (mode as u32).into()
+    }
+
     /// Enables or disables the `ForceInterpreter` option. By default, the option is disabled.
     ///
     /// # Argument
     ///
     /// * `enable` - Whether the option turns on or not.
+    #[deprecated(
+        note = "use `set_run_mode` instead; since WasmEdge 0.17.0, passing `false` is a no-op"
+    )]
     pub fn interpreter_mode(&mut self, enable: bool) {
         unsafe { ffi::WasmEdge_ConfigureSetForceInterpreter(self.inner.0, enable) }
     }
 
     /// Checks if the `ForceInterpreter` option turns on or not.
+    #[deprecated(note = "use `get_run_mode` instead")]
     pub fn interpreter_mode_enabled(&self) -> bool {
         unsafe { ffi::WasmEdge_ConfigureIsForceInterpreter(self.inner.0) }
     }
@@ -802,8 +837,8 @@ mod tests {
             config.get_aot_compiler_output_format(),
             CompilerOutputFormat::Wasm,
         );
-        // Note: interpreter_mode is enabled by default in WasmEdge 0.17.0+
-        assert!(config.interpreter_mode_enabled());
+        // Note: the default run mode is interpreter since WasmEdge 0.17.0
+        assert_eq!(config.get_run_mode(), RunMode::Interpreter);
         #[cfg(feature = "aot")]
         assert!(!config.interruptible_enabled());
 
@@ -828,7 +863,7 @@ mod tests {
         #[cfg(feature = "aot")]
         config.generic_binary(true);
         config.count_instructions(true);
-        config.interpreter_mode(true);
+        config.set_run_mode(RunMode::Aot);
 
         // check new settings
         assert!(config.multi_memories_enabled());
@@ -854,7 +889,13 @@ mod tests {
         assert!(config.generic_binary_enabled());
         assert!(config.is_instruction_counting());
         assert!(config.is_time_measuring());
-        assert!(config.interpreter_mode_enabled());
+        assert_eq!(config.get_run_mode(), RunMode::Aot);
+
+        // check the run mode round-trip
+        config.set_run_mode(RunMode::Jit);
+        assert_eq!(config.get_run_mode(), RunMode::Jit);
+        config.set_run_mode(RunMode::Interpreter);
+        assert_eq!(config.get_run_mode(), RunMode::Interpreter);
 
         // check function_references
         // Enabling function_references also enables reference_types.

--- a/crates/wasmedge-types/src/lib.rs
+++ b/crates/wasmedge-types/src/lib.rs
@@ -230,6 +230,65 @@ impl From<CompilerOutputFormat> for i32 {
     }
 }
 
+/// Defines the execution mode of the WasmEdge runtime.
+///
+/// Since WasmEdge 0.17.0, the runtime no longer executes the AOT-compiled
+/// code embedded in a WASM file by default for safety reasons. The execution
+/// mode must be set explicitly to enable the JIT or AOT execution.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum RunMode {
+    /// Executes WASM in the interpreter. AOT-compiled code embedded in a WASM
+    /// file is ignored. This is the default mode.
+    #[default]
+    Interpreter,
+
+    /// Executes WASM with the just-in-time compiler.
+    Jit,
+
+    /// Executes the AOT-compiled code. This is the only mode that loads AOT
+    /// custom sections from a universal WASM file or `dlopen`s a
+    /// shared-library WASM artifact.
+    Aot,
+}
+impl From<u32> for RunMode {
+    fn from(val: u32) -> RunMode {
+        match val {
+            0 => RunMode::Interpreter,
+            1 => RunMode::Jit,
+            2 => RunMode::Aot,
+            _ => panic!("Unknown RunMode value: {val}"),
+        }
+    }
+}
+impl From<RunMode> for u32 {
+    fn from(val: RunMode) -> u32 {
+        match val {
+            RunMode::Interpreter => 0,
+            RunMode::Jit => 1,
+            RunMode::Aot => 2,
+        }
+    }
+}
+impl From<i32> for RunMode {
+    fn from(val: i32) -> RunMode {
+        match val {
+            0 => RunMode::Interpreter,
+            1 => RunMode::Jit,
+            2 => RunMode::Aot,
+            _ => panic!("Unknown RunMode value: {val}"),
+        }
+    }
+}
+impl From<RunMode> for i32 {
+    fn from(val: RunMode) -> i32 {
+        match val {
+            RunMode::Interpreter => 0,
+            RunMode::Jit => 1,
+            RunMode::Aot => 2,
+        }
+    }
+}
+
 /// Defines WasmEdge host module registration enum.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum HostRegistration {

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,7 @@ use crate::WasmEdgeResult;
 #[cfg(feature = "aot")]
 use crate::{CompilerOptimizationLevel, CompilerOutputFormat};
 use wasmedge_sys as sys;
+use wasmedge_types::RunMode;
 
 /// Defines a builder for creating a [Config].
 #[derive(Debug, Default)]
@@ -85,7 +86,7 @@ impl ConfigBuilder {
         inner.gc(self.common_config.gc);
         inner.tail_call(self.common_config.tail_call);
         inner.function_references(self.common_config.function_references);
-        inner.interpreter_mode(self.common_config.interpreter_mode);
+        inner.set_run_mode(self.common_config.run_mode);
 
         if let Some(stat_config) = self.stat_config {
             inner.count_instructions(stat_config.count_instructions);
@@ -211,8 +212,15 @@ impl Config {
     }
 
     /// Checks if the `ForceInterpreter` option turns on or not.
+    #[deprecated(note = "use `run_mode` instead")]
     pub fn interpreter_mode_enabled(&self) -> bool {
+        #[allow(deprecated)]
         self.inner.interpreter_mode_enabled()
+    }
+
+    /// Returns the execution mode.
+    pub fn run_mode(&self) -> RunMode {
+        self.inner.get_run_mode()
     }
 
     /// Returns the optimization level of AOT compiler.
@@ -311,7 +319,7 @@ pub struct CommonConfigOptions {
     gc: bool,
     tail_call: bool,
     function_references: bool,
-    interpreter_mode: bool,
+    run_mode: RunMode,
 }
 impl CommonConfigOptions {
     /// Creates a new instance of [CommonConfigOptions].
@@ -329,7 +337,7 @@ impl CommonConfigOptions {
     /// * gc: false,
     /// * tail_call: false,
     /// * function_references: false,
-    /// * interpreter_mode: false,
+    /// * run_mode: RunMode::Interpreter,
     pub fn new() -> Self {
         Self {
             mutable_globals: true,
@@ -344,7 +352,7 @@ impl CommonConfigOptions {
             gc: false,
             tail_call: false,
             function_references: false,
-            interpreter_mode: false,
+            run_mode: RunMode::Interpreter,
         }
     }
 
@@ -494,9 +502,32 @@ impl CommonConfigOptions {
     /// # Argument
     ///
     /// * `enable` - Whether the option turns on or not.
+    #[deprecated(
+        note = "use `run_mode` instead; since WasmEdge 0.17.0, passing `false` is a no-op"
+    )]
     pub fn interpreter_mode(self, enable: bool) -> Self {
+        // Keep the historical "don't force" semantic: only `true` selects the
+        // interpreter; `false` leaves the current mode untouched.
+        if enable {
+            self.run_mode(RunMode::Interpreter)
+        } else {
+            self
+        }
+    }
+
+    /// Sets the execution mode: interpreter, JIT, or AOT. By default, the mode is
+    /// [RunMode::Interpreter].
+    ///
+    /// Since WasmEdge 0.17.0, only [RunMode::Aot] loads the AOT custom sections from a universal
+    /// WASM file or `dlopen`s a shared-library WASM artifact; in the other modes, the AOT data is
+    /// ignored and the WASM runs in the selected engine.
+    ///
+    /// # Argument
+    ///
+    /// * `mode` - The execution mode to set.
+    pub fn run_mode(self, mode: RunMode) -> Self {
         Self {
-            interpreter_mode: enable,
+            run_mode: mode,
             ..self
         }
     }
@@ -516,7 +547,7 @@ impl Default for CommonConfigOptions {
     /// * threads: false,
     /// * tail_call: false,
     /// * function_references: false,
-    /// * interpreter_mode: false,
+    /// * run_mode: RunMode::Interpreter,
     fn default() -> Self {
         Self::new()
     }
@@ -748,7 +779,7 @@ mod tests {
             .sign_extension_operators(true)
             .simd(true)
             .multi_memories(true)
-            .interpreter_mode(true);
+            .run_mode(RunMode::Aot);
 
         let compiler_options = CompilerConfigOptions::default()
             .dump_ir(true)
@@ -781,7 +812,7 @@ mod tests {
         assert!(config.sign_extension_operators_enabled());
         assert!(config.simd_enabled());
         assert!(config.multi_memories_enabled());
-        assert!(config.interpreter_mode_enabled());
+        assert_eq!(config.run_mode(), RunMode::Aot);
 
         // check compiler config options
         assert!(config.dump_ir_enabled());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,8 +144,8 @@ pub use vm::Vm;
 
 pub use wasmedge_types::{
     error, wat2wasm, CompilerOptimizationLevel, CompilerOutputFormat, ExternalInstanceType,
-    FuncType, GlobalType, HostRegistration, MemoryType, Mutability, RefType, TableType, ValType,
-    WasmEdgeResult,
+    FuncType, GlobalType, HostRegistration, MemoryType, Mutability, RefType, RunMode, TableType,
+    ValType, WasmEdgeResult,
 };
 
 #[cfg(all(feature = "async", target_os = "linux"))]


### PR DESCRIPTION
## Summary

Since WasmEdge 0.17.0, the runtime no longer executes the AOT-compiled code in a compiled WASM by default for safety reasons (see the 0.17.0 breaking-change note and WasmEdge/WasmEdge#5169). The engine is selected by the new run-mode configuration — interpreter (default), JIT, or AOT — and only the AOT mode loads AOT custom sections from a universal WASM or `dlopen`s a shared-library artifact. This SDK had no way to set the mode, so compiled WASM silently fell back to the interpreter.

This PR exposes the new `WasmEdge_ConfigureSetRunMode` / `WasmEdge_ConfigureGetRunMode` C API across the layers:

- **wasmedge-types**: new `RunMode` enum (`Interpreter`/`Jit`/`Aot`) mirroring `enum WasmEdge_RunMode`.
- **wasmedge-sys**: `Config::set_run_mode` / `get_run_mode`; deprecate `interpreter_mode` / `interpreter_mode_enabled`, matching the upstream deprecation of the `ForceInterpreter` APIs (passing `false` is a no-op since 0.17.0).
- **wasmedge-sdk**: `CommonConfigOptions::run_mode` option (default interpreter, same as upstream) and `Config::run_mode` getter; the deprecated `interpreter_mode` builder stays as a shim preserving the historical "don't force" semantics; `RunMode` is re-exported from the crate root.
- `test_aot` now sets `RunMode::Aot`, so it executes the compiled code again instead of silently interpreting it.

## Verification

On macOS arm64 (`bundled,aot,ffi`):
- `cargo test --workspace --exclude async-wasi -- --test-threads=1 --skip test_vmbuilder`: 78 passed / 0 failed / 12 ignored, identical to the 0.17.1 baseline.
- `cargo clippy --lib --examples -- -D warnings` (both CI feature sets) and `cargo fmt --all -- --check` are clean.
- Behavioral check: a fib(28) universal WASM runs ~80x faster with `RunMode::Aot` (458µs) than with the default interpreter mode (37.2ms), confirming the mode engages the AOT engine.

Fixes #145
