### PR TITLE
fix(sys): point rerun-if-changed at build_standalone.rs

### DIFF
--- a/crates/wasmedge-sys/build.rs
+++ b/crates/wasmedge-sys/build.rs
@@ -69,7 +69,7 @@ fn find_libwasmedge<'a, L: IntoIterator<Item = &'a Option<LibWasmEdgePaths>>>(
 fn main() {
     // rerun if the other build sources change
     println!("cargo:rerun-if-changed=build_paths.rs");
-    println!("cargo:rerun-if-changed=build_install.rs");
+    println!("cargo:rerun-if-changed=build_standalone.rs");
 
     // find the location of the libwasmedge
     let paths = if cfg!(feature = "standalone") {


### PR DESCRIPTION
## Summary

- `crates/wasmedge-sys/build.rs` emits `cargo:rerun-if-changed=build_install.rs`, but no such file has ever existed in this repository.
- A `rerun-if-changed` path that does not exist makes cargo treat the package as dirty on **every** build, so `wasmedge-sys` and everything downstream recompile even when nothing changed.
- The intended target is `build_standalone.rs`, the second build source module. One-character-class fix, one line.

## Root cause

`build.rs` declares two build source modules:

```rust
mod build_paths;
mod build_standalone;
```

and then declares what should retrigger the build script:

```rust
// rerun if the other build sources change
println!("cargo:rerun-if-changed=build_paths.rs");
println!("cargo:rerun-if-changed=build_install.rs");   // <- never existed
```

Both the directives and the modules arrived together in #40 (`refactor build script`, 2023-07-28). That commit added `build_paths.rs` and `build_standalone.rs` — never a `build_install.rs`. The directive has named a non-existent file since the day it was written; `build_install` appears exactly once in the entire repository, on that line.

## Impact

Cargo reports the package dirty on every invocation, regardless of whether anything changed:

```
Dirty wasmedge-sys v0.20.0: the file `crates/wasmedge-sys/build_install.rs` is missing
   Compiling wasmedge-sys v0.20.0
```

Two consequences:

1. **Incremental builds never hit for this crate.** `wasmedge-sys` and its dependents rebuild unconditionally, locally and in every CI job that reuses a cargo cache.
2. **The trigger it was meant to provide was silently disabled.** Because the emitted path pointed at nothing, edits to `build_standalone.rs` were never tracked through this mechanism.

## Validation

Measured on macOS arm64 with `--features bundled`:

| | cargo's verdict on a no-op rebuild | wall clock |
|---|---|---|
| before | `Dirty: build_install.rs is missing` → recompiles | 1.57s |
| after | `Fresh` | 0.07s |

Reverse check, confirming the restored trigger actually works — after the fix, touching `build_standalone.rs` reports:

```
Dirty wasmedge-sys v0.20.0: the file `crates/wasmedge-sys/build_standalone.rs` has changed
   Compiling wasmedge-sys v0.20.0
```

Also run on the fixed tree:

- `cargo build --release --features bundled` → pass
- `cargo test --release --features bundled` → 9 + 22 + 5 tests pass, 0 failures
- `cargo clippy --release --lib --examples --features bundled,aot,async,ffi -- -D warnings` → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
