### PR TITLE
ci: convert ci-build.yml into a scheduled upstream canary

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,4 +1,4 @@
-name: Continuous integration
+name: Upstream canary (WasmEdge development HEAD)
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -9,21 +9,18 @@ env:
   # group_imports, ...) that stable rustfmt silently ignores.
   RUSTFMT_TOOLCHAIN: "nightly-2026-07-16"
 
+# Every other workflow builds against a released WasmEdge. This one checks out
+# the WasmEdge repository without a ref, so it builds the runtime's development
+# HEAD and catches upstream C API breakage before it reaches a release.
+#
+# It is deliberately not attached to push or pull_request: the extra full
+# WasmEdge build would roughly double PR turnaround, and an upstream breakage
+# would then block changes that have nothing to do with it.
 on:
-  push:
-    branches:
-      - 'bump/**'
-    paths-ignore:
-      - "**/*.md"
-      - ".github/workflows/standalone.yml"
-      - ".github/workflows/rust-static-lib.yml"
-  pull_request:
-    branches:
-      - 'bump/**'
-    paths-ignore:
-      - "**/*.md"
-      - ".github/workflows/standalone.yml"
-      - ".github/workflows/rust-static-lib.yml"
+  schedule:
+    # Mondays, 03:00 UTC.
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
 
 jobs:
   build_ubuntu:


### PR DESCRIPTION
## Summary

- `ci-build.yml` has **never run**. The Actions API reports `total_count: 0` for it.
- Its triggers were narrowed to `bump/**` in #99 on 2024-01-01, and no `bump/**` branch has ever existed in this repository — 0 local, 0 remote, 0 in merge history.
- The coverage it was meant to provide is real and not duplicated elsewhere, so this restores it as a weekly schedule plus manual dispatch instead of deleting the workflow.

## How it died

```
2024-01-01  fa3f3ce  [WIP] Feat/virtual file sys (#99)
            ├─ added ci-build-release-lib.yml
            └─ narrowed ci-build.yml from "all push/PR" to bump/** only
```

Before that commit `ci-build.yml` ran on every push and every pull request. The commit message includes a `[CI]: update CI trigger conditions` bullet; the apparent intent was to split work between `bump/**` branches and everything else. The `bump/**` convention was never adopted, so the workflow simply stopped running and nothing signalled it — an inert workflow produces no failures, no warnings, and no missing check.

## Why not just delete it

It is the only workflow that builds WasmEdge's **development HEAD**:

| workflow | WasmEdge source |
|---|---|
| **ci-build.yml** | **repository checkout with no `ref` → development HEAD** |
| ci-build-release-lib.yml (Ubuntu, macOS) | `install_v2.sh -v 0.17.1` |
| ci-build-release-lib.yml (Windows) | latest release tag, built from source |
| integration-test.yml, standalone.yml, rust-static-lib.yml | released versions |

For a binding crate, "did upstream change the C API" is worth knowing before the next release rather than after. That signal has not existed since 2024-01.

## Why scheduled rather than on every PR

Restoring the original push/PR triggers would add a full WasmEdge build — LLVM included — to every pull request, roughly doubling turnaround. Worse, an upstream breakage would then fail PRs that have nothing to do with it, and the usual response to that is to start ignoring the check.

A weekly run surfaces the same breakage while keeping it off the critical path. `workflow_dispatch` is included so it can be triggered on demand, for example before cutting a release.

```yaml
on:
  schedule:
    # Mondays, 03:00 UTC.
    - cron: "0 3 * * 1"
  workflow_dispatch:
```

The jobs themselves are unchanged — same three platforms, same build steps, same test invocations.

## Rename

`name:` becomes `Upstream canary (WasmEdge development HEAD)`. "Continuous integration" sitting next to "Continuous integration with the release version of Wasmedge" told you nothing about which one did what. Since the workflow has never produced a check run, no existing branch protection or required-check configuration can be referring to the old name.

## Notes for reviewers

- **First run may well be red.** This has not built against upstream HEAD since 2024-01, so it may need a round of fixes before it is green. That is the workflow doing its job rather than a reason to hold the change — but it is the reason it is scheduled rather than blocking.
- **GitHub disables scheduled workflows after 60 days of repository inactivity.** Not a concern at this repository's activity level, worth knowing.
- **Scheduled workflows only run from the default branch**, so this takes effect once merged to `main`, not from this PR.
- `ci-build-release-lib.yml` has a related but separate defect: its `push: branches: ['!bump/**']` is a pure-negative filter, which GitHub treats as matching nothing. All 100 of its recorded runs are `pull_request`, zero are `push`. Left alone deliberately — every merge path goes through a PR, so the practical gap is a direct push to `main`.

## Validation

- `actionlint` on the changed file → no new findings. One pre-existing `SC2155` at line 118 (`export LLVM_DIR="$(brew --prefix llvm)/..."`) is present on `main` too and is untouched here.
- YAML parses; triggers resolve to `{'schedule': [{'cron': '0 3 * * 1'}], 'workflow_dispatch': None}`; all three jobs (`build_ubuntu`, `build_macos`, `build_windows`) intact.
- Checked for event-context references that would go empty under `schedule`: the only one is `concurrency.group`, which uses `github.head_ref || github.ref` and falls back correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
