### PR TITLE
fix(sys): compile fiber-for-wasmedge only on Linux targets

### DIFF
--- a/crates/wasmedge-sys/Cargo.toml
+++ b/crates/wasmedge-sys/Cargo.toml
@@ -14,7 +14,6 @@ version = "0.21.0"
 
 [dependencies]
 log = "0.4"
-fiber-for-wasmedge = { version = "14.0.4", optional = true }
 libc = "0.2.94"
 paste = "1.0.5"
 scoped-tls = "1"
@@ -30,6 +29,7 @@ cfg-if.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 async-wasi = { workspace = true, optional = true }
+fiber-for-wasmedge = { version = "14.0.4", optional = true }
 setjmp = "0.1"
 
 [build-dependencies]


### PR DESCRIPTION
## What this PR does

Moves `fiber-for-wasmedge` from the plain `[dependencies]` table into `[target.'cfg(target_os = "linux")'.dependencies]`, next to `async-wasi` which already uses this shape for the same reason.

## Why

Every use of the fiber crate lives behind `cfg(all(feature = "async", target_os = "linux"))` — the whole `async` module disappears on other platforms. But the dependency itself was activated by the `async` feature on **every** platform, and `async` is a default feature of `wasmedge-sdk`. Consequences:

- macOS/iOS/Windows consumers built the fiber crate and its cc-compiled context-switching assembly for nothing
- any fiber release that fails to compile on a non-Linux target breaks those consumers outright — exactly how #130 presented (iOS-sim build failing with 12 compile errors inside `fiber-for-wasmedge`; the currently pinned 14.0.4 happens to build for iOS again, but nothing consumes it there)

A `dep:` feature entry only activates a target-specific optional dependency on matching targets, so `async` keeps working unchanged on Linux (gnu and musl).

## Verification

| target | `cargo tree -i fiber-for-wasmedge` |
|---|---|
| aarch64-apple-ios | absent ✅ |
| x86_64-pc-windows-msvc | absent ✅ |
| macOS host | absent ✅ |
| x86_64-unknown-linux-gnu | present ✅ |
| x86_64-unknown-linux-musl | present ✅ |

- `cargo check -p wasmedge-sdk --target aarch64-apple-ios` (default features) now passes
- macOS host test suites unchanged: wasmedge-sys 40 passed, wasmedge-sdk 16 passed
- Linux compile coverage is exercised by the existing Ubuntu CI jobs (async in both clippy and test gates)

Resolves the failure mode reported in #130. (Running WasmEdge on iOS still requires a libwasmedge built for iOS — that part is upstream runtime territory.)